### PR TITLE
alias extractor should not match use in anonymous functions

### DIFF
--- a/src/Hal/Component/OOP/Extractor/AliasExtractor.php
+++ b/src/Hal/Component/OOP/Extractor/AliasExtractor.php
@@ -44,9 +44,11 @@ class AliasExtractor implements ExtractorInterface {
         $expression = $this->searcher->getUnder(array(';'), $n, $tokens);
         if(preg_match('!use\s+(.*)\s+as\s+(.*)!i', $expression, $matches)) {
             list(, $real, $alias) = $matches;
-        } else if(preg_match('!use\s+(.*)\s*!i', $expression, $matches)) {
+        } else if(preg_match('!use\s+([^\s\(]+)\s*!i', $expression, $matches)) {
             list(, $real) = $matches;
             $alias = $real;
+        } else {
+            $alias = $real = null;
         }
 
 

--- a/src/Hal/Component/OOP/Extractor/Extractor.php
+++ b/src/Hal/Component/OOP/Extractor/Extractor.php
@@ -84,8 +84,10 @@ class Extractor {
 
                 case T_USE:
                     $alias = $this->extractors->alias->extract($n, $tokens);
-                    $mapOfAliases[$alias->alias] = $alias->name;
-                    $class && $class->setAliases($mapOfAliases);
+                    if (null !== $alias->name && null !== $alias->alias) {
+                        $mapOfAliases[$alias->alias] = $alias->name;
+                        $class && $class->setAliases($mapOfAliases);
+                    }
                     break;
 
                 case T_PAAMAYIM_NEKUDOTAYIM:

--- a/tests/Hal/Component/OOP/AliasExtractorTest.php
+++ b/tests/Hal/Component/OOP/AliasExtractorTest.php
@@ -1,0 +1,79 @@
+<?php
+namespace Test\Hal\Component\OOP\Extractor;
+use Hal\Component\OOP\Extractor\AliasExtractor;
+use Hal\Component\Token\TokenCollection;
+
+/**
+ * @group oop
+ */
+class AliasExtractorTest extends \PHPUnit_Framework_TestCase {
+
+    public function testExtractUseStatement() {
+        $n = 10;
+        $tokens = new TokenCollection(array());
+
+        $searcher = $this->getMockBuilder('\Hal\Component\OOP\Extractor\Searcher')->disableOriginalConstructor()->getMock();
+        $searcher->expects($this->once())
+            ->method('getUnder')
+            ->with(array(";"), $n, $tokens)
+            ->will($this->returnValue('use Hal\Component\OOP\Extractor\AliasExtractor'));
+
+        $extractor = new AliasExtractor($searcher);
+        $actual = $extractor->extract($n, $tokens);
+
+        $expected = (object)array('name' => 'Hal\Component\OOP\Extractor\AliasExtractor', 'alias' => 'Hal\Component\OOP\Extractor\AliasExtractor');
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testExtractUseStatementWithAlias() {
+        $n = 10;
+        $tokens = new TokenCollection(array());
+
+        $searcher = $this->getMockBuilder('\Hal\Component\OOP\Extractor\Searcher')->disableOriginalConstructor()->getMock();
+        $searcher->expects($this->once())
+            ->method('getUnder')
+            ->with(array(";"), $n, $tokens)
+            ->will($this->returnValue('use Hal\Component\OOP\Extractor\AliasExtractor as AliasExtractor'));
+
+        $extractor = new AliasExtractor($searcher);
+        $actual = $extractor->extract($n, $tokens);
+
+        $expected = (object)array('name' => 'Hal\Component\OOP\Extractor\AliasExtractor', 'alias' => 'AliasExtractor');
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testExtractAnonymousFunction() {
+        $n = 10;
+        $tokens = new TokenCollection(array());
+
+        $searcher = $this->getMockBuilder('\Hal\Component\OOP\Extractor\Searcher')->disableOriginalConstructor()->getMock();
+        $searcher->expects($this->once())
+            ->method('getUnder')
+            ->with(array(";"), $n, $tokens)
+            ->will($this->returnValue('use ($variable) { if ($variable > 0) return $variable'));
+
+        $extractor = new AliasExtractor($searcher);
+        $actual = $extractor->extract($n, $tokens);
+
+        $expected = (object)array('name' => null, 'alias' => null);
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testExtractAnonymousFunctionWithoutWithspace() {
+        $n = 10;
+        $tokens = new TokenCollection(array());
+
+        $searcher = $this->getMockBuilder('\Hal\Component\OOP\Extractor\Searcher')->disableOriginalConstructor()->getMock();
+        $searcher->expects($this->once())
+            ->method('getUnder')
+            ->with(array(";"), $n, $tokens)
+            ->will($this->returnValue('use($variable) { if ($variable > 0) return $variable'));
+
+        $extractor = new AliasExtractor($searcher);
+        $actual = $extractor->extract($n, $tokens);
+
+        $expected = (object)array('name' => null, 'alias' => null);
+        $this->assertEquals($expected, $actual);
+    }
+
+}


### PR DESCRIPTION
I adjusted the AliasExtractor so it does not match agains the use keyword in the context of anonymous functions
- this should fix #14
- additionally this fixes some wrong alias entries for classes with such use statements where the whitespace was set between use and (
- added test cases for all 4 scenarios I could think off

I wasn't sure how you would the null value handling. If you prefer it otherwise just let me know.
