### PR TITLE
Define 'metrics' binary in composer

### DIFF
--- a/bin/metrics
+++ b/bin/metrics
@@ -1,5 +1,0 @@
-#!/usr/bin/env php
-<?php
-
-include 'metrics.php';
-

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,6 @@
         "phpunit/phpunit": "3.7.*@dev"
     },
     "bin": [
-        "bin/metrics"
+        "bin/metrics.php"
     ]
 }


### PR DESCRIPTION
- Places a metrics binary in vendor/bin when added as a project dependency
  - (this might be a dependency under "require-dev")
- Adds a user-friendly binary name (metrics vs metrics.php)
  - (its nicer to run ./vendor/bin/metrics rather than ./vendor/bin/metrics.php)
