### PR TITLE
Unix linebreak on Windows

### DIFF
--- a/src/Hal/Metrics/Complexity/Text/Length/Loc.php
+++ b/src/Hal/Metrics/Complexity/Text/Length/Loc.php
@@ -60,13 +60,13 @@ class Loc {
                     $cloc++;
                     break;
                 case T_DOC_COMMENT:
-                    $cloc += substr_count($token->getValue(), PHP_EOL) + 1;
+                    $cloc += count(preg_split('/\r\n|\r|\n/', $token->getValue()));
                     break;
             }
         }
 
         $info
-            ->setLoc(substr_count($content, PHP_EOL))
+            ->setLoc(count(preg_split('/\r\n|\r|\n/', $content)) - 1)
             ->setCommentLoc($cloc)
             ->setLogicalLoc($lloc)
         ;


### PR DESCRIPTION
Hi,

I think there is an error when using `PHP_EOL`. By using `\n` as linebreak on windows there are 0 lines found. With `count(file($filename))` the problem does not appear. I'm not sure how to make a test case for this because it depends on the environment …
