### PR TITLE
determine separator globally for all results

### DIFF
--- a/templates/html/summary/report-tabular.js.twig
+++ b/templates/html/summary/report-tabular.js.twig
@@ -103,11 +103,16 @@
         var parents = [
             { name: "temporary", _values: []}
         ];
-        var final, e, level ;
+        var final, e, level, separator;
+        separator = "/";
         for(i = 0; i < len; i++) {
-            var separator;
+            if (result[i].name.indexOf("\\") !== -1) {
+                separator = "\\";
+                break;
+            }
+        }
+        for(i = 0; i < len; i++) {
             e = result[i];
-            separator = e.name.indexOf("\\") !== -1 ? "\\" : "/";
             level = (e.name.split(separator).length - 1);
             if(!e.name.match(/php$/)) {
                 parents[level + 1] = e;


### PR DESCRIPTION
When using the PhpStorm Plugin on windows, we need another way to determine the separator because the root path does not contain a `\` but consists of `/`
(e.g. `J:/xampp/htdocs/MyProject/src\Path\To\My\Class.php`)
