### PR TITLE
remove non-breaking space from validateIn function

### DIFF
--- a/templates/html/assets/functions.js.twig
+++ b/templates/html/assets/functions.js.twig
@@ -39,7 +39,7 @@
     }
 
     function validateIn(results, key, type) {
-        type = type || 'average';
+        type = type || 'average';
         var value = results[type] ? results[type][key] : results[key];
         return validate(key, value);
     }


### PR DESCRIPTION
Hi!

I have removed a non-breaking space found in the validateIn function.
It caused Javascript errors, when executed with ant.
