### PR TITLE
fix #45 (error with php in path)

### DIFF
--- a/templates/html/summary/report-tabular.js.twig
+++ b/templates/html/summary/report-tabular.js.twig
@@ -114,7 +114,7 @@
         for(i = 0; i < len; i++) {
             e = result[i];
             level = (e.name.split(separator).length - 1);
-            if(!e.name.match(/php$/)) {
+            if(!e.name.match(/\.php$/)) {
                 parents[level + 1] = e;
                 parents[level]._values.push(e);
             } else {


### PR DESCRIPTION
Have a look at my [comment](https://github.com/Halleck45/PhpMetrics/issues/45#issuecomment-55792132) in #45
There seems to be an error with `php` as folder in path of scanned files. Scan works but output doesn't because of a wrong parent level.
