### PR TITLE
Improving variable naming in Searcher and some cs and docblock

### DIFF
--- a/src/Hal/Component/OOP/Extractor/Searcher.php
+++ b/src/Hal/Component/OOP/Extractor/Searcher.php
@@ -212,4 +212,4 @@ class Searcher {
         
         return ($position - $startingToken >= $limit);
     }
-};
+}

--- a/src/Hal/Component/OOP/Extractor/Searcher.php
+++ b/src/Hal/Component/OOP/Extractor/Searcher.php
@@ -113,7 +113,7 @@ class Searcher {
 
     /**
      * 
-     * @param TokenCollection[] $tokens
+     * @param TokenCollection $tokens
      * @param int $startingToken
      * @return null|int 
      */
@@ -130,7 +130,7 @@ class Searcher {
     }
     /**
      * 
-     * @param TokenCollection[] $tokens
+     * @param TokenCollection $tokens
      * @return int|null
      */
     public function getClassNamePosition(TokenCollection $tokens)
@@ -150,7 +150,7 @@ class Searcher {
      * 
      * @param int $tokenType
      * @param int $startingToken
-     * @param TokenCollection[] $tokens
+     * @param TokenCollection $tokens
      * @return null|int
      */
     public function getPositionOfPrevious($tokenType, $startingToken, TokenCollection $tokens)
@@ -168,7 +168,7 @@ class Searcher {
      * 
      * @param int $tokenType
      * @param int $startingToken
-     * @param TokenCollection[] $tokens
+     * @param TokenCollection $tokens
      * @return null|int
      */
     public function getPositionOfNext($tokenType, $startingToken, TokenCollection $tokens) 
@@ -187,7 +187,7 @@ class Searcher {
      * 
      * @param int $tokenType
      * @param int $startingToken
-     * @param TokenCollection[] $tokens
+     * @param TokenCollection $tokens
      * @param int $limit
      * @return bool
      */
@@ -202,7 +202,7 @@ class Searcher {
      * 
      * @param int $tokenType
      * @param int $startingToken
-     * @param TokenCollection[] $tokens
+     * @param TokenCollection $tokens
      * @param int $limit
      * @return bool
      */

--- a/src/Hal/Component/OOP/Extractor/Searcher.php
+++ b/src/Hal/Component/OOP/Extractor/Searcher.php
@@ -22,73 +22,80 @@ class Searcher {
      * Get value under limiters
      *
      * @param string[] $delimiters
-     * @param int $n
+     * @param int $startingToken
      * @param \Hal\Component\Token\TokenCollection $tokens
      * @return null|string
      */
-    public function getUnder(array $delimiters, &$n, TokenCollection $tokens) {
+    public function getUnder(array $delimiters, &$startingToken, TokenCollection $tokens) 
+    {
         $end = sizeof($tokens, COUNT_NORMAL);
         $value = '';
-        while($n < $end) {
-            $token = $tokens[$n];
+        while($startingToken < $end) {
+            $token = $tokens[$startingToken];
             if(in_array($token->getValue(), $delimiters)) {
                 return $value;
             }
             $value .= $token->getValue();
-            $n++;
+            $startingToken++;
         }
+        
         return null;
     }
 
     /**
      * Get non whitespace previous token
      *
-     * @param $n
+     * @param int $startingToken
      * @param \Hal\Component\Token\TokenCollection $tokens
      * @return null
      */
-    public function getPrevious(&$n, TokenCollection $tokens) {
-        $p = $n - 1;
+    public function getPrevious(&$startingToken, TokenCollection $tokens)
+    {
+        $p = $startingToken - 1;
         for($i = $p ; $i > 0; $i--) {
             if(T_WHITESPACE !== $tokens[$i]->getType()) {
                 return $tokens[$i];
             }
         }
+        
         return null;
     }
 
     /**
      * Get name following token
      *
-     * @param $n
+     * @param int $startingToken
      * @param \Hal\Component\Token\TokenCollection $tokens
      * @return null|string
      */
-    public function getFollowingName(&$n, TokenCollection $tokens) {
-        $n = $n + 2;
-        return $this->getUnder(array('{', ' ', ';', '(', '::'), $n, $tokens);
+    public function getFollowingName(&$startingToken, TokenCollection $tokens)
+    {
+        $startingToken = $startingToken + 2;
+        
+        return $this->getUnder(array('{', ' ', ';', '(', '::'), $startingToken, $tokens);
     }
 
     /**
      * Get the position of the brace which closes the next brace
      *
-     * @param integer $n
+     * @param int $startingToken
      * @param TokenCollection $tokens
-     * @return null
+     * @return null|int
      */
-    public function getPositionOfClosingBrace(&$n, TokenCollection $tokens) {
+    public function getPositionOfClosingBrace(&$startingToken, TokenCollection $tokens)
+    {
         // search the end of the method
         $openBrace = 0;
         $start = null;
         $len = sizeof($tokens);
-        for($i = $n; $i < $len; $i++) {
+        for($i = $startingToken; $i < $len; $i++) {
             $token = $tokens[$i];
             if(T_STRING == $token->getType()) {
                 switch($token->getValue()) {
                     case '{':
                         $openBrace++;
                         if(is_null($start)) {
-                            $start = $n = $i + 1;
+                            $start = $startingToken = $i + 1;
                         }
                         break;
                     case '}':
@@ -100,19 +107,32 @@ class Searcher {
                 }
             }
         }
+        
         return null;
     }
 
-    public function getExtendPosition(TokenCollection $tokens, $start)
+    /**
+     * 
+     * @param TokenCollection[] $tokens
+     * @param int $startingToken
+     * @return null|int 
+     */
+    public function getExtendPosition(TokenCollection $tokens, $startingToken)
     {
-        for($i = $start; $i > 0; $i--) {
+        for($i = $startingToken; $i > 0; $i--) {
             $token = $tokens[$i];
             if ($token->getValue() === 'extends') {
                 return $i;
             }
         }
+        
         return null;
     }
+    /**
+     * 
+     * @param TokenCollection[] $tokens
+     * @return int|null
+     */
     public function getClassNamePosition(TokenCollection $tokens)
     {
         $len = sizeof($tokens);
@@ -122,35 +142,74 @@ class Searcher {
                 return $i;
             }
         }
+        
         return null;
     }
 
-    public function getPositionOfPrevious($tokenType, $n, TokenCollection $tokens) {
-        for($i = $n; $i > 0; $i--) {
+    /**
+     * 
+     * @param int $tokenType
+     * @param int $startingToken
+     * @param TokenCollection[] $tokens
+     * @return null|int
+     */
+    public function getPositionOfPrevious($tokenType, $startingToken, TokenCollection $tokens)
+    {
+        for($i = $startingToken; $i > 0; $i--) {
             if($tokenType == $tokens->get($i)->getType()) {
                 return $i;
             }
         }
+        
         return null;
     }
 
-    public function getPositionOfNext($tokenType, $n, TokenCollection $tokens) {
+    /**
+     * 
+     * @param int $tokenType
+     * @param int $startingToken
+     * @param TokenCollection[] $tokens
+     * @return null|int
+     */
+    public function getPositionOfNext($tokenType, $startingToken, TokenCollection $tokens) 
+    {
         $len = sizeof($tokens);
-        for($i = $n; $i < $len; $i++) {
+        for($i = $startingToken; $i < $len; $i++) {
             if($tokenType == $tokens->get($i)->getType()) {
                 return $i;
             }
         }
+        
         return null;
     }
 
-    public function isPrecededBy($tokenType, $n, TokenCollection $tokens, $limit = 2) {
-        $position = $this->getPositionOfPrevious($tokenType, $n, $tokens);
-        return ($n - $position <= $limit);
+    /**
+     * 
+     * @param int $tokenType
+     * @param int $startingToken
+     * @param TokenCollection[] $tokens
+     * @param int $limit
+     * @return bool
+     */
+    public function isPrecededBy($tokenType, $startingToken, TokenCollection $tokens, $limit = 2)
+    {
+        $position = $this->getPositionOfPrevious($tokenType, $startingToken, $tokens);
+        
+        return ($startingToken - $position <= $limit);
     }
-
-    public function isFollowedBy($tokenType, $n, TokenCollection $tokens, $limit = 2) {
-        $position = $this->getPositionOfNext($tokenType, $n, $tokens);
-        return ($position - $n >= $limit);
+    
+    /**
+     * 
+     * @param int $tokenType
+     * @param int $startingToken
+     * @param TokenCollection[] $tokens
+     * @param int $limit
+     * @return bool
+     */
+    public function isFollowedBy($tokenType, $startingToken, TokenCollection $tokens, $limit = 2)
+    {
+        $position = $this->getPositionOfNext($tokenType, $startingToken, $tokens);
+        
+        return ($position - $startingToken >= $limit);
     }
 };


### PR DESCRIPTION
I find `$startingToken` a better name than `$n` 
And I took this opportunity to add docblocks to some methods and to fix cs.