### PR TITLE
Good value for violations warning ?

### DIFF
--- a/src/Hal/Application/Formater/Violations/Xml.php
+++ b/src/Hal/Application/Formater/Violations/Xml.php
@@ -77,7 +77,8 @@ class Xml implements FormaterInterface {
                     $violation->setAttribute('rule', $key);
                     $violation->setAttribute('ruleset', $key);
                     $violation->setAttribute('externalInfoUrl', 'http://halleck45.github.io/PhpMetrics/documentation/index.html');
-                    $violation->setAttribute('priority', $result == Validator::WARNING ? 0 : 1);
+
+                    $violation->setAttribute('priority', $result == Validator::WARNING ? 3 : 1);
 
                     $violation->nodeValue = sprintf('the "%1$s" value (%2$s) of "%3$s" is incorrect. The configured %1$s threshold is %4$s'
                     , $key


### PR DESCRIPTION
In violation formatter, priority value are incorrect.

priority: The priority for the rule. This can be a value in the range 1-5, where 1 is the highest priority and 5 the lowest priority.

usually Warning is 3