### PR TITLE
Phar is pushed to bintray

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ composer.lock
 Vagrantfile
 provision.sh
 .vagrant
-Makefile
 /nbproject
 phpmetrics.yml.dist
 log

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: false
 addons:
   apt_packages:
     - graphviz
+    - ruby2.1
 
 php:
     - 5.4
@@ -17,7 +18,24 @@ before_script:
   - composer selfupdate --quiet
   - composer install --prefer-dist --no-interaction --no-progress
   - ./vendor/bin/phpunit
-  - composer update --prefer-dist --no-interaction --no-progress
 
 script:
-  - ./vendor/bin/phpunit
+  - make test
+
+after_script:
+  - gem install semver
+  - make build
+
+
+deploy:
+  provider: bintray
+  file: "artifacts/bintray.json"
+  user: ${BINTRAY_USER}
+  key: ${BINTRAY_KEY}
+  on:
+    branch: artifact
+
+env:
+  global:
+  - secure: cGI2zwz9C9kwUmYmoVAcS/0xNqNCbuQbtVD0AFBKWeWUdX+1ZtfHOrl1YXLbowBc8+ha8PsMrkif/OV/0tTzSvyyJOBDtbfvbwmNAbVBRQtyJsVWTn+Dnv0RVRR51GjdUkfzMGtmZk1Gsq7Ofcunm3wUVLlpocv/VTZXmPUeDBitcg8Q2WfUNcGMWMKfoN5uzwFUyPFVHwsy+Qa47V31rYCKvmyL+vg9S72tMI4XagmygOZuKI8/VdQoxdd7BhoY9F8qJ0gp4hMAW8uZmGennXGmisO4hULUW7tlyc1D8sV3hP6ywFlu6aN5QsXnEhrcCOZQgh4pASQaGOailvYzLZ+HSV5AdonrZamw3yAoztZkO53iQDIP7OepZQDZ7zoMz9G19asNs37oYxUuoszoTf+G6Ph45aDVo8boCV+Z7uCpGNJUSaDXBc3GRKDbE6YNNpJXDhL25975ZxmB1mtGqLRyV7KU501BGM4gs+LF7OQK7MK22vifvm/rvAOdbD0BbPRQbgyp6oSUM+6IpHbU0q6/yTegfqnrM9H/Rw0mg32DFNy23dlQagsOQyfq+Gq0TyskzsG4OvIY0UCHugIxTgxm2J0t7zfnlw6tVbwb4a5C4T+xxr9ts/TivGgxPd41fAIwjCZnaTgHU28cTU2Q2NlOJJsPXOb4NJjfVMwjzlc=
+  - secure: q5TO9rAr6GonU8AlPBa0STtRZYYibb9Df+BQdzXwGC6lRxjZfnjDODzA2vh0E92aoFlNJeQCVg3Px/ASFjzVDuaCO6t0jUs+zcCsMSq3IweU2/h7Dy0mJmPvWIkGXP2XMF0/sCuMvoo+mscMN9jCRnqdBCdEDQVy5kA2+tUxB3M/u77pARADVoxrfDMZJqo3H2e6ZrPAuh7BFBGrLfJLb4l6NVF+QgCB5dyG5pG/BF2m3oN7Ymve3jRD0UEK3XF30tk27vl/8GQbbVMhCBY1RFuq8w40TVEo40VsG7bf0MWu76lfpd87HcPSiGVFgo1ZtvPPRZgnaGl87c+upkF4WQwMERQ/37zNh4SwjYWDsrD1BIQqk/iOUg9UiKM9jIUph3psGDSk16PhqjRO5XUNTycwDtEPj71qvtiuj+ixc0hpa3TFNiLC5zlhCOAEJLq0GMIa3NEY+lpLtvxFtLxdyaeWgnRAGMGIH2MbQH5Xr/b4gbTkEctakZOPQLp8GN1oXLmnSZYS1RWAyBSsBs93eoBWwXRSXQnRoQj/QQsl6fTKImEWTwWtVV7BvwJW94j44vDz5wmCwGtuCMXp0AEni9UlXUMfo7A/pk4kvWHX17z5X5TkgVvS7hkO6JKNtWMwS+3JWUqeR91ugsh0Ammm/U7qW2kmAin7DbOKRdQCtIg=

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ php:
 before_script:
   - composer selfupdate --quiet
   - composer install --prefer-dist --no-interaction --no-progress
-  - ./vendor/bin/phpunit
 
 script:
   - make test
@@ -26,7 +25,6 @@ after_script:
   - gem install semver
   - make build
 
-
 deploy:
   provider: bintray
   file: "artifacts/bintray.json"
@@ -34,6 +32,7 @@ deploy:
   key: ${BINTRAY_KEY}
   on:
     branch: master
+    php: '5.6'
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: false
 addons:
   apt_packages:
     - graphviz
-    - ruby2.1
 
 php:
     - 5.4
@@ -22,8 +21,10 @@ script:
   - make test
 
 after_script:
-  - gem install semver
   - make build
+
+before_deploy:
+  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && apt-get install -qq -y ruby2.1 && gem install semver'
 
 deploy:
   provider: bintray

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ deploy:
   user: ${BINTRAY_USER}
   key: ${BINTRAY_KEY}
   on:
-    branch: artifact
+    branch: master
 
 env:
   global:

--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,8 @@
-REPLACE=`semver tag`
-
-# Build phar
-build: test
-	@echo Copying sources
-	@mkdir -p /tmp/phpmetrics-build
-	@cp * -R /tmp/phpmetrics-build
-	@rm -Rf /tmp/phpmetrics-build/vendor /tmp/phpmetrics-build/composer.lock
-
-	@echo Releasing sources
-	@sed -i -r "s/(v[0-9]+\.[0-9]+\.[0-9]+)/`semver tag`/g" bin/phpmetrics
-	@sed -i -r "s/(v[0-9]+\.[0-9]+\.[0-9]+)/`semver tag`/g" templates/html/version.html.twig
-
-	@echo Releasing phar
-	@sed -i "s/<VERSION>/`semver tag`/g" /tmp/phpmetrics-build/build.php
-
-	@echo Installing dependencies
-	@cd /tmp/phpmetrics-build && composer install --no-dev --optimize-autoloader --prefer-dist
-
-	@echo Building phar
-	@cd /tmp/phpmetrics-build && php build.php
-	@cp /tmp/phpmetrics-build/build/phpmetrics.phar build/phpmetrics.phar
-	@rm -Rf /tmp/phpmetrics-build
-
-	@echo Testing phar
-	./vendor/bin/phpunit -c phpunit.xml.dist --group=binary &&	echo "Done"
+include artifacts/Makefile
 
 # Run unit tests
 test:
 	./vendor/bin/phpunit -c phpunit.xml.dist
-
 
 # Publish new release. Usage:
 #   make tag VERSION=(major|minor|patch)
@@ -36,6 +10,11 @@ test:
 tag:
 	@semver inc $(VERSION)
 	@echo "New release: `semver tag`"
+	@echo Releasing sources
+	@sed -i -r "s/(v[0-9]+\.[0-9]+\.[0-9]+)/`semver tag`/g" bin/phpmetrics
+	@sed -i -r "s/(v[0-9]+\.[0-9]+\.[0-9]+)/`semver tag`/g" templates/html/version.html.twig
+	@sed -i -r "s/(v[0-9]+\.[0-9]+\.[0-9]+)/`semver tag`/g" artifacts/bintray.json
+	@sed -i -r "s/([0-9]{4}\-[0-9]{2}\-[0-9]{2})/`date +%Y-%m-%d`/g" artifacts/bintray.json
 
 
 # Tag git with last release

--- a/artifacts/Makefile
+++ b/artifacts/Makefile
@@ -1,0 +1,3 @@
+include artifacts/phar/Makefile
+
+build: build-phar

--- a/artifacts/README.md
+++ b/artifacts/README.md
@@ -1,0 +1,13 @@
+# Artifacts
+
+This folder contains tools for generating and publishing artifacts (.phar, .deb...)
+
+Artifacts are stored at Bintray
+
+## Contributing
+
+Each type of artifact MUST be in a specific folder. For example, phar artifact goes in `./phar` folder.
+
+Each folder MUST have a Makefile. This Makefile should be included in `artifacts/Makefile`.
+
+All artifacts MUST be published to Bintray with the travis-ci build. Please check the `./artifacts/bintray.json` file.

--- a/artifacts/bintray.json
+++ b/artifacts/bintray.json
@@ -1,0 +1,25 @@
+{
+  "package": {
+    "name": "phpmetrics",
+    "repo": "phpmetrics",
+    "subject": "phpmetrics",
+    "desc": "Static analyzer for PHP",
+    "website_url": "http://www.phpmetrics.org",
+    "issue_tracker_url": "https://github.com/phpmetrics/phpmetrics/issues",
+    "vcs_url": "https://github.com/phpmetrics/phpmetrics.git",
+    "licenses": ["MIT"]
+  },
+  "version": {
+    "name": "v1.9.0",
+    "desc": "Latest version of PhpMetrics",
+    "released": "2016-02-18",
+    "vcs_tag": "v1.9.0",
+    "attributes": [],
+    "gpgSign": false
+  },
+  "files":
+  [
+    {"includePattern": "build/(phpmetrics.*)", "uploadPattern": "/$1" }
+  ],
+  "publish": true
+}

--- a/artifacts/phar/Makefile
+++ b/artifacts/phar/Makefile
@@ -1,0 +1,20 @@
+# Build phar
+build-phar: test
+	@echo Copying sources
+	@mkdir -p /tmp/phpmetrics-build
+	@cp * -R /tmp/phpmetrics-build
+	@rm -Rf /tmp/phpmetrics-build/vendor /tmp/phpmetrics-build/composer.lock
+
+	@echo Releasing phar
+	@sed -i "s/<VERSION>/`semver tag`/g" /tmp/phpmetrics-build/artifacts/phar/build.php
+
+	@echo Installing dependencies
+	@cd /tmp/phpmetrics-build && composer install --no-dev --optimize-autoloader --prefer-dist
+
+	@echo Building phar
+	@cd /tmp/phpmetrics-build && php artifacts/phar/build.php
+	@cp /tmp/phpmetrics-build/build/phpmetrics.phar build/phpmetrics.phar
+	@rm -Rf /tmp/phpmetrics-build
+
+	@echo Testing phar
+	./vendor/bin/phpunit -c phpunit.xml.dist --group=binary &&	echo "Done"

--- a/artifacts/phar/build.php
+++ b/artifacts/phar/build.php
@@ -1,5 +1,5 @@
 <?php
-chdir(__DIR__);
+chdir(__DIR__.'/../../');
 
 if (!file_exists('vendor/autoload.php')) {
   echo '[ERROR] It\'s required to run "composer install" before building PhpMetrics!' . PHP_EOL;


### PR DESCRIPTION
I think that downloading phar from Github is not a good idea:

+ no statistic
+ it's hard to download an older release
+ Github is not a download platform

I would like to host all files to bintray. If this PR is merged, I'll create a redirection on my server, so we'll be able to download phar at `http://download.phpmetrics.org/phpmetrics.phar`.

@fonsecas72 @UFOMelkor, what do you think ?