### PR TITLE
Build the phar with a lower version of php to enhance compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ deploy:
   key: ${BINTRAY_KEY}
   on:
     branch: master
-    php: '5.6'
+    php: '5.4'
   skip_cleanup: true
 
 env:


### PR DESCRIPTION
Currently the phar is built with PHP 5.6. Therefore composer choses a Symfony version that is not compatible with PHP 5.4.

This PR changes the PHP version to 5.4 to ensure that the choosen dependencies are compatible with PHP 5.4. The tradeoff is that if the chosen version for PHP 5.4 of one dependency is not compatible with a greater PHP version, we will get the same problem (which could not be solved then).

The other approach would be to use a higher version of PHP (7.0 or 5.6) but run composer with the `--prefer-lowest`. This will always support the higher versions and the lowest possible PHP version that could be accomplished. (while writing this I convince myself that this is the better solution^^)

Thoughts?


Fix #219 