### PR TITLE
metric documentation: first experiment

### DIFF
--- a/src/Hal/Component/Tree/Graph.php
+++ b/src/Hal/Component/Tree/Graph.php
@@ -13,7 +13,7 @@ class Graph implements \Countable
 {
 
     /**
-     * @var array
+     * @var Node[]
      */
     private $datas = array();
 
@@ -82,7 +82,7 @@ class Graph implements \Countable
 
     /**
      * @param $key
-     * @return null
+     * @return Node|null
      */
     public function get($key)
     {

--- a/src/Hal/Metric/Class_/Complexity/CyclomaticComplexityVisitor.php
+++ b/src/Hal/Metric/Class_/Complexity/CyclomaticComplexityVisitor.php
@@ -2,6 +2,7 @@
 namespace Hal\Metric\Class_\Complexity;
 
 use Hal\Component\Reflected\Method;
+use Hal\Metric\Information\CyclomaticComplexity;
 use Hal\Metric\Metrics;
 use PhpParser\Node;
 use PhpParser\Node\Stmt;
@@ -92,7 +93,7 @@ class CyclomaticComplexityVisitor extends NodeVisitorAbstract
                 }
             }
 
-            $class->set('ccn', $ccn);
+            $class->set(CyclomaticComplexity::ID, $ccn);
         }
     }
 }

--- a/src/Hal/Metric/Class_/Complexity/KanDefectVisitor.php
+++ b/src/Hal/Metric/Class_/Complexity/KanDefectVisitor.php
@@ -2,6 +2,7 @@
 namespace Hal\Metric\Class_\Complexity;
 
 use Hal\Component\Reflected\Method;
+use Hal\Metric\Information\KanDefect;
 use Hal\Metric\Metrics;
 use PhpParser\Node;
 use PhpParser\Node\Stmt;
@@ -59,7 +60,7 @@ class KanDefectVisitor extends NodeVisitorAbstract
             });
 
             $defect = 0.15 + 0.23 *  $while + 0.22 *  $select + 0.07 * $if;
-            $class->set('kanDefect', round($defect, 2));
+            $class->set(KanDefect::ID, round($defect, 2));
         }
     }
 }

--- a/src/Hal/Metric/Class_/Component/MaintainabilityIndexVisitor.php
+++ b/src/Hal/Metric/Class_/Component/MaintainabilityIndexVisitor.php
@@ -2,8 +2,15 @@
 namespace Hal\Metric\Class_\Component;
 
 use Hal\Metric\FunctionMetric;
+use Hal\Metric\Information\CommentLinesOfCode;
+use Hal\Metric\Information\CommentWeight;
+use Hal\Metric\Information\CyclomaticComplexity;
+use Hal\Metric\Information\LinesOfCode;
+use Hal\Metric\Information\LogicalLinesOfCode;
+use Hal\Metric\Information\MaintainabilityIndex;
+use Hal\Metric\Information\MaintainabilityIndexWithoutComments;
 use Hal\Metric\Metrics;
-use Hoa\Ruler\Model\Bag\Scalar;
+//use Hoa\Ruler\Model\Bag\Scalar;
 use PhpParser\Node;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeVisitorAbstract;
@@ -55,16 +62,16 @@ class MaintainabilityIndexVisitor extends NodeVisitorAbstract
                 $classOrFunction = new FunctionMetric($node->name);
                 $this->metrics->attach($classOrFunction);
             }
-            if (null === $lloc = $classOrFunction->get('lloc')) {
+            if (null === $lloc = $classOrFunction->get(LogicalLinesOfCode::ID)) {
                 throw new \LogicException('please enable length (lloc) visitor first');
             }
-            if (null === $cloc = $classOrFunction->get('cloc')) {
+            if (null === $cloc = $classOrFunction->get(CommentLinesOfCode::ID)) {
                 throw new \LogicException('please enable length (cloc) visitor first');
             }
-            if (null === $loc = $classOrFunction->get('loc')) {
+            if (null === $loc = $classOrFunction->get(LinesOfCode::ID)) {
                 throw new \LogicException('please enable length (loc) visitor first');
             }
-            if (null === $ccn = $classOrFunction->get('ccn')) {
+            if (null === $ccn = $classOrFunction->get(CyclomaticComplexity::ID)) {
                 throw new \LogicException('please enable McCabe visitor first');
             }
             if (null === $volume = $classOrFunction->get('volume')) {
@@ -87,6 +94,8 @@ class MaintainabilityIndexVisitor extends NodeVisitorAbstract
             if ($loc > 0) {
                 $CM = $cloc / $loc;
                 $commentWeight = 50 * sin(sqrt(2.4 * $CM));
+            } else {
+                $commentWeight = 0;
             }
 
             // maintainability index
@@ -94,9 +103,9 @@ class MaintainabilityIndexVisitor extends NodeVisitorAbstract
 
             // save result
             $classOrFunction
-                ->set('mi', round($mi, 2))
-                ->set('mIwoC', round($MIwoC, 2))
-                ->set('commentWeight', round($commentWeight, 2));
+                ->set(MaintainabilityIndex::ID, round($mi, 2))
+                ->set(MaintainabilityIndexWithoutComments::ID, round($MIwoC, 2))
+                ->set(CommentWeight::ID, round($commentWeight, 2));
             $this->metrics->attach($classOrFunction);
         }
     }

--- a/src/Hal/Metric/Class_/Structural/LcomVisitor.php
+++ b/src/Hal/Metric/Class_/Structural/LcomVisitor.php
@@ -3,6 +3,7 @@ namespace Hal\Metric\Class_\Structural;
 
 use Hal\Component\Tree\Graph;
 use Hal\Component\Tree\Node as TreeNode;
+use Hal\Metric\Information\LackOfCohesionOfMethods;
 use Hal\Metric\Metrics;
 use PhpParser\Node;
 use PhpParser\Node\Stmt;
@@ -88,7 +89,7 @@ class LcomVisitor extends NodeVisitorAbstract
                 $paths += $this->traverse($node);
             }
 
-            $class->set('lcom', $paths);
+            $class->set(LackOfCohesionOfMethods::ID, $paths);
         }
     }
 

--- a/src/Hal/Metric/Class_/Text/HalsteadVisitor.php
+++ b/src/Hal/Metric/Class_/Text/HalsteadVisitor.php
@@ -3,7 +3,7 @@ namespace Hal\Metric\Class_\Text;
 
 use Hal\Metric\FunctionMetric;
 use Hal\Metric\Metrics;
-use Hoa\Ruler\Model\Bag\Scalar;
+//use Hoa\Ruler\Model\Bag\Scalar;
 use PhpParser\Node;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeVisitorAbstract;

--- a/src/Hal/Metric/Class_/Text/LengthVisitor.php
+++ b/src/Hal/Metric/Class_/Text/LengthVisitor.php
@@ -2,6 +2,9 @@
 namespace Hal\Metric\Class_\Text;
 
 use Hal\Metric\FunctionMetric;
+use Hal\Metric\Information\CommentLinesOfCode;
+use Hal\Metric\Information\LinesOfCode;
+use Hal\Metric\Information\LogicalLinesOfCode;
 use Hal\Metric\Metrics;
 use PhpParser\Node;
 use PhpParser\Node\Stmt;
@@ -69,9 +72,9 @@ class LengthVisitor extends NodeVisitorAbstract
 
             // save result
             $classOrFunction
-                ->set('cloc', $cloc)
-                ->set('loc', $loc)
-                ->set('lloc', $lloc);
+                ->set(CommentLinesOfCode::ID, $cloc)
+                ->set(LinesOfCode::ID, $loc)
+                ->set(LogicalLinesOfCode::ID, $lloc);
             $this->metrics->attach($classOrFunction);
         }
     }

--- a/src/Hal/Metric/Information/AbstractInformation.php
+++ b/src/Hal/Metric/Information/AbstractInformation.php
@@ -1,0 +1,128 @@
+<?php
+namespace Hal\Metric\Information;
+
+abstract class AbstractInformation
+{
+    const ID = 'undefined';
+    const LINK_TEMPLATE = '/information/metric#{metricID}';
+
+    /** @var string */
+    protected $name = '';
+
+    /** @var string */
+    protected $shortDescription = '';
+
+    /** @var string */
+    protected $longDescription = '';
+
+    /** @var string[] */
+    protected $links = [];
+
+    /** @var string if empty, this is a base metric that is not calculated from any other */
+    protected $formula = '';
+
+    /**
+     * unique symbolic identifier used in BagTrait to store values for this metric
+     * @return string
+     */
+    public function getID()
+    {
+        return static::ID;
+    }
+
+    /**
+     * short descriptive name
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * A one line description suitable for html title mouse over hints
+     * @return string plain text
+     */
+    public function getShortDescription()
+    {
+        return $this->shortDescription;
+    }
+
+    /**
+     * A longer description containing html
+     * @return string html including p tags
+     */
+    public function getLongDescription()
+    {
+        return $this->longDescription;
+    }
+
+    /**
+     * return a url to the documentation for this
+     * @param null $metricID
+     * @return string
+     */
+    public function getUrl($metricID = null)
+    {
+        if (empty($metricID)) {
+            $metricID = $this->getID();
+        }
+        return str_replace('{metricID}', self::LINK_TEMPLATE, $metricID);
+    }
+
+    /**
+     * return a formula in html with links to the other metrics that it is calculated from (if any)
+     * @return string
+     */
+    public function renderFormulaToHtml()
+    {
+        $result = [];
+        $parts  = preg_split('|[\s+\(\)]+|', $this->formula);
+        foreach ($parts as $part) {
+            if (ctype_alpha($part)) {
+                // turn the variable in the formula into a link to its documentation
+                $part = '<a href="' . $this->getUrl($part) . '">' . $part . '</a>';
+            }
+            $result[] = $part;
+        }
+        return join(' ', $result);
+    }
+
+    /**
+     * links are title => url. If is_numeric(title) then the url is the title.
+     * Assumes no escaping needed because links in the source code are safe.
+     * @return array raw url => a href tag
+     */
+    public function renderLinksToHtml()
+    {
+        $links = [];
+        foreach ($this->links as $title => $url) {
+            if (is_numeric($title)) {
+                $title = $url;
+            }
+            $links[$url] = '<a href="' . $url . '">' . $title . '</a>';
+        }
+        return $links;
+    }
+
+    /**
+     * return html documentation for this metric. Use this in a loop to iterate all metrics and output html
+     * documentation page(s)
+     * @return string html
+     */
+    public function renderToHtml()
+    {
+        $output  = '<h2>' . $this->getName() . '</h2>' .
+            '<p><em>' . $this->getShortDescription() . '</em></p>' .
+            $this->getLongDescription();
+        $formula = $this->renderFormulaToHtml();
+        if (!empty($formula)) {
+            $output .= '<p>' . $formula . '</p>';
+        }
+        $links = $this->renderLinksToHtml();
+        if (!empty($links)) {
+            $output .= '<ul><li>' . join('</li><li>', $links) . '</li>';
+        }
+        return $output;
+    }
+}

--- a/src/Hal/Metric/Information/CommentLinesOfCode.php
+++ b/src/Hal/Metric/Information/CommentLinesOfCode.php
@@ -1,0 +1,9 @@
+<?php
+namespace Hal\Metric\Information;
+
+class CommentLinesOfCode extends AbstractInformation
+{
+    const ID = 'cloc';
+    protected $name = 'Comment Lines';
+    protected $shortDescription = 'Total number of lines which are comments';
+}

--- a/src/Hal/Metric/Information/CommentWeight.php
+++ b/src/Hal/Metric/Information/CommentWeight.php
@@ -1,0 +1,10 @@
+<?php
+namespace Hal\Metric\Information;
+
+class CommentWeight extends AbstractInformation
+{
+    const ID = 'commentWeight';
+    protected $name = 'Comment Weight';
+    protected $shortDescription = 'Ratio between logical code and comments';
+    protected $formula = '50 * sin(sqrt(2.4 * cloc/loc))'; // todo use IDs
+}

--- a/src/Hal/Metric/Information/CyclomaticComplexity.php
+++ b/src/Hal/Metric/Information/CyclomaticComplexity.php
@@ -1,0 +1,10 @@
+<?php
+namespace Hal\Metric\Information;
+
+class CyclomaticComplexity extends AbstractInformation
+{
+    const ID = 'ccn';
+    protected $name = 'Cyclomatic Complexity';
+    protected $shortDescription = 'Number of linearly independent paths';
+    protected $links = ['http://en.wikipedia.org/wiki/Cyclomatic_complexity'];
+}

--- a/src/Hal/Metric/Information/KanDefect.php
+++ b/src/Hal/Metric/Information/KanDefect.php
@@ -1,0 +1,10 @@
+<?php
+namespace Hal\Metric\Information;
+
+class KanDefect extends AbstractInformation
+{
+    const ID = 'kanDefect';
+    protected $name = 'Kan\'s defects';
+    protected $shortDescription = 'todo where is this from?';
+    protected $longDescription = '<p>todo describe</p><p>0.15 + 0.23 *  number of do…while() + 0.22 *  number of select() + 0.07 * number of if()</p>';
+}

--- a/src/Hal/Metric/Information/LackOfCohesionOfMethods.php
+++ b/src/Hal/Metric/Information/LackOfCohesionOfMethods.php
@@ -1,0 +1,11 @@
+<?php
+namespace Hal\Metric\Information;
+
+class LackOfCohesionOfMethods extends AbstractInformation
+{
+    const ID = 'lcom';
+    protected $name = 'Lack of cohesion of methods';
+    protected $shortDescription = 'Do the methods in this class belong together?';
+    protected $longDescription = '<p>Looking at the internal dependencies of this class, do the methods have a single responsibility and work together on the same data? Or do they appear to operate on more than one separate concept?</p>';
+    protected $links = ['https://en.wikipedia.org/wiki/Cohesion_(computer_science)'];
+}

--- a/src/Hal/Metric/Information/LinesOfCode.php
+++ b/src/Hal/Metric/Information/LinesOfCode.php
@@ -1,0 +1,9 @@
+<?php
+namespace Hal\Metric\Information;
+
+class LinesOfCode extends AbstractInformation
+{
+    const ID = 'loc';
+    protected $name = 'Lines of Code';
+    protected $shortDescription = 'Total number of lines';
+}

--- a/src/Hal/Metric/Information/LogicalLinesOfCode.php
+++ b/src/Hal/Metric/Information/LogicalLinesOfCode.php
@@ -1,0 +1,11 @@
+<?php
+namespace Hal\Metric\Information;
+
+class LogicalLinesOfCode extends AbstractInformation
+{
+    const ID = 'lloc';
+    protected $name = 'Logical Lines of Code';
+    protected $shortDescription = 'Lines of code excluding blank lines and comments';
+    protected $longDescription = '<p>Definitions vary for what a line of code actually is. We use PhpParser\PrettyPrinter to reformat the code and count the resulting lines.</p>';
+    protected $links = ['https://en.wikipedia.org/wiki/Source_lines_of_code'];
+}

--- a/src/Hal/Metric/Information/MaintainabilityIndex.php
+++ b/src/Hal/Metric/Information/MaintainabilityIndex.php
@@ -1,0 +1,11 @@
+<?php
+namespace Hal\Metric\Information;
+
+class MaintainabilityIndex extends AbstractInformation
+{
+    const ID = 'mi';
+    protected $name = 'Maintainability Index';
+    protected $shortDescription = 'How maintainable is this code?';
+    protected $links = ['https://en.wikipedia.org/wiki/Maintainability'];
+    protected $formula = MaintainabilityIndexWithoutComments::ID . ' + ' . CommentWeight::ID;
+}

--- a/src/Hal/Metric/Information/MaintainabilityIndexWithoutComments.php
+++ b/src/Hal/Metric/Information/MaintainabilityIndexWithoutComments.php
@@ -1,0 +1,18 @@
+<?php
+namespace Hal\Metric\Information;
+
+class MaintainabilityIndexWithoutComments extends AbstractInformation
+{
+    const ID = 'mIwoC';
+    protected $name = 'Maintainability Index Without Comments';
+    protected $shortDescription = 'How maintainable is this code?';
+    protected $longDescription = '<p>Maintainability index evaluates the maintainability of any project. It provides a score between 0 to 118.
+This score is standard, and works for any language : PHP, .Net, Java... Value ranges are:</p>
+<ul>
+<li>&lt;64: low maintainability. The project has probably technical debt.</li>
+<li>65-84: medium maintainability. The project has problems, but nothing really serious.</li>
+<li>&gt;85: high maintainability. The project is probably good.</li>
+</ul>';
+    protected $links = ['https://en.wikipedia.org/wiki/Maintainability'];
+    protected $formula = '171 - (5.2 * \log( volume )) - (0.23 * ' . CyclomaticComplexity::ID . ') - (16.2 * \log(' . LogicalLinesOfCode::ID . '))) * 100 / 171';
+}


### PR DESCRIPTION
Work in progress to show you what i was thinking... no tests yet. They will come later if you approve the ideas...

Each metric has its own class which contains documentation (as you suggested). 

Each documentation class has
- a const ID which can be the symbolic name eg use LinesOfCode::ID instead of 'loc' throughout the code base. This will make it clear that 'loc' in one place is the same as all the other 'loc's. (and make them very easy to find in phpStorm and other IDEs).
- a short title to use as the title of a column in a table (for example)
- a short description to use as the abbr title
- a longer description where we describe what the metric is for, how to use it, what a good value is, what a bad value is (acceptable range)
- zero or more links to source documents, more definition, academic papers etc
- a formula which describes how it is calculated
- render*() functions which can turn it into html for display to the user. Of specific interest is AbstractInformation::renderFormulaToHtml() which will automatically convert metric names into links to those metrics in the documentation (what base url should we use here?).

So I've started documenting maybe 1/10th of the metrics. A lot of missing information (eg could not find info on Kan's Defects) but this can be filled in later once the whole structure is in place.

for me to do later
- finish creating documentation classes for all metrics (that are displayed to the user)
- replace strings eg 'loc' with their ID throughout the code base
- create an html page to display it all
- edit the other parts of the html report to link to the documentation or show abbr or title='' attributes where relevant.
- tests

need help with (when finished)
- better descriptions and links
