### PR TITLE
Don't trigger the issuer on suppressed errors

### DIFF
--- a/src/Hal/Component/Issue/Issuer.php
+++ b/src/Hal/Component/Issue/Issuer.php
@@ -48,6 +48,9 @@ class Issuer
      */
     public function onError($errno, $errstr, $errfile, $errline)
     {
+        if (error_reporting() == 0) {
+            return;
+        }
         $php = PHP_VERSION;
         $os = php_uname();
         $phpmetrics = getVersion();


### PR DESCRIPTION
The error handler is also called if the error is suppressed by an @.
We can catch this by using error_reporting() that will be always 0 if
the error was suppressed.

If the error_reporting has been set to 0 by `php.ini` the user want get anything. Perhaps we need to cover this, but I'm not sure whether user disable error_reporting on cli.

Fixes #240 
Fixes #242