### PR TITLE
Docs change: add symlink to run from anywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ mv phpmetrics.phar /usr/local/bin/phpmetrics
 
     composer global require 'phpmetrics/phpmetrics'
 
+To run PhpMetrics from anywhere, run the following command (may require root):
+
+    ln -s ~/.composer/vendor/phpmetrics/phpmetrics/bin/phpmetrics /usr/local/bin/phpmetrics
+
 # Usage
 
 > Do not hesitate to visit the [official documentation](http://www.phpmetrics.org).


### PR DESCRIPTION
Added the `ln` command to symlink the composer-installed binary to /usr/local/bin/ so that it can be run from any location.