### PR TITLE
Fix undefined MaintainabilityIndex on interfaces.

### DIFF
--- a/src/Hal/Metric/Consolidated.php
+++ b/src/Hal/Metric/Consolidated.php
@@ -43,20 +43,17 @@ class Consolidated
         $project = [];
         $nbInterfaces = 0;
         foreach ($metrics->all() as $key => $item) {
-            if ($item instanceof ClassMetric) {
-                $classes[] = $item->all();;
-            }
-            if ($item instanceof InterfaceMetric) {
+            $classItem = get_class($item);
+            if (ClassMetric::class === $classItem) {
+                $classes[] = $item->all();
+            } elseif (InterfaceMetric::class === $classItem) {
                 $nbInterfaces++;
-            }
-            if ($item instanceof FunctionMetric) {
-                $functions[$key] = $item->all();;
-            }
-            if ($item instanceof FileMetric) {
-                $files[$key] = $item->all();;
-            }
-            if ($item instanceof ProjectMetric) {
-                $project[$key] = $item->all();;
+            } elseif (FunctionMetric::class === $classItem) {
+                $functions[$key] = $item->all();
+            } elseif (FileMetric::class === $classItem) {
+                $files[$key] = $item->all();
+            } elseif (ProjectMetric::class === $classItem) {
+                $project[$key] = $item->all();
             }
         }
 
@@ -82,7 +79,6 @@ class Consolidated
             'afferentCoupling' => [],
             'efferentCoupling' => [],
             'difficulty' => [],
-            'lcom' => [],
             'mi' => [],
         ];
 
@@ -96,7 +92,7 @@ class Consolidated
                 array_push($avg->$k, $item->get($k));
             }
         }
-        $sum->nbClasses = sizeof($classes) - $nbInterfaces;
+        $sum->nbClasses = count($classes);
         $sum->nbInterfaces = $nbInterfaces;
 
         foreach ($avg as &$a) {

--- a/src/Hal/Metric/Metrics.php
+++ b/src/Hal/Metric/Metrics.php
@@ -42,7 +42,7 @@ class Metrics implements \JsonSerializable
     }
 
     /**
-     * @return array
+     * @return Metric[]
      */
     public function all()
     {


### PR DESCRIPTION
As InterfaceMetric extends ClassMetric, during the consolidation, both parsed interfaces an classes where added into the list of `$classes`.
This resulted in an array `$classes` containing all classes and interfaces, while this array was used into tables and graphs in the HTML rendering. As interfaces have no metrics calculated from, the rendering goes to fail, espacially the metric "MaintainabilityIndex" was missing.

Using the workaround of comparing the FQN of the metric classes used for each `$item`, we can avoid this confusion and split correctly interfaces data and class data in the consolidated result object.