### PR TITLE
Run on Trusty Beta Container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,15 +19,17 @@ matrix:
   - php: hhvm-nightly
 
 before_script:
-- composer selfupdate --quiet
-- composer install --prefer-dist --no-interaction --no-progress
+  - composer selfupdate --quiet
+  - composer install --prefer-dist --no-interaction --no-progress
+  # Disable JIT compilation in hhvm, as the JIT is useless for short live scripts like tests.
+  - if [[ $TRAVIS_PHP_VERSION = hhvm* ]]; then echo 'hhvm.jit = 0' >> /etc/hhvm/php.ini; fi
 
 script:
-- make test
+  - make test
 
 before_deploy:
-- make build
-- git add -f build/phpmetrics.deb build/phpmetrics.phar
+  - make build
+  - git add -f build/phpmetrics.deb build/phpmetrics.phar
 
 deploy:
   - provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,34 @@
-language: php
 sudo: false
-php:
-- 5.4
-- 5.5
-- 5.6
-- 7.0
-- nightly
-- hhvm
-- hhvm-nightly
+dist: trusty
+language: php
+
 matrix:
+  fast_finish: true
+  include:
+  - php: 5.4
+  - php: 5.5
+  - php: 5.6
+  - php: 7.0
+  - php: 7.1
+  - php: nightly
+  - php: hhvm
+  - php: hhvm-nightly
   allow_failures:
   - php: nightly
   - php: hhvm
   - php: hhvm-nightly
+
 before_script:
 - composer selfupdate --quiet
 - composer install --prefer-dist --no-interaction --no-progress
+
 script:
 - make test
+
 before_deploy:
 - make build
 - git add -f build/phpmetrics.deb build/phpmetrics.phar
+
 deploy:
   - provider: releases
     api_key:


### PR DESCRIPTION
- add PHP 7.1
- Runs the tests on the newer Trusty containers since this repo is not affected by the current mysql issues in the trusty beta container.

Added benefit, This provides the current HHVM version (3.18.1 as of this PR) and the correct hhvm nightly (current dev) These will also track with each release (i.e. will be 3.19 when 3.19 is released) and nightly will actually be the nightly dev release. ... **you are currently on EOL versions of HHVM since precise was dropped back at hhvm 3.6**

If testing against HHVM LST versions is desired follow this guide. https://docs.travis-ci.com/user/languages/php#HHVM-versions

NOTE: If testing against HHVM in php 7 mode is desired: HHVM php 7 mode currently has an issue that messes up composer under php 7 mode, see facebook/hhvm#7198 once that BUG is fixed HHVM PHP 7 mode testing could be added