### PR TITLE
Fix travis ci on PHP7.1 by not allowing phpunit 6 to be installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,10 @@ php:
 - 7.0
 - nightly
 - hhvm
-- hhvm-nightly
 matrix:
   allow_failures:
   - php: nightly
   - php: hhvm
-  - php: hhvm-nightly
 before_script:
 - composer selfupdate --quiet
 - composer install --prefer-dist --no-interaction --no-progress

--- a/composer.json
+++ b/composer.json
@@ -34,11 +34,11 @@
         "php": ">=5.4",
         "ext-dom": "*",
         "ext-tokenizer": "*",
-        "symfony/console": "~2.5|3.*",
-        "nikic/php-parser": "2.*"
+        "symfony/console": "~2.5|~3.0",
+        "nikic/php-parser": "~2.0|~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=4.8.27"
+        "phpunit/phpunit": ">=4.8.27,<6.0"
     },
     "bin": [
         "bin/phpmetrics"


### PR DESCRIPTION
Tests are failing in Travis CI for PHP 7.1 version, because phpunit 6 is installed and it has moved to namespaces that are not supported in phpmetric tests now.
Also nikic/php-parser 3 verision installation is allowed now.