### PR TITLE
(Mostly) adjust PHPDoc types

### DIFF
--- a/src/Hal/Application/Analyze.php
+++ b/src/Hal/Application/Analyze.php
@@ -33,7 +33,7 @@ class Analyze
 {
 
     /**
-     * @var OutputInterface
+     * @var Output
      */
     private $output;
 
@@ -49,7 +49,7 @@ class Analyze
 
     /**
      * Analyze constructor.
-     * @param OutputInterface $output
+     * @param Output $output
      */
     public function __construct(Config $config, Output $output, Issuer $issuer)
     {

--- a/src/Hal/Component/Issue/Issuer.php
+++ b/src/Hal/Component/Issue/Issuer.php
@@ -25,13 +25,13 @@ class Issuer
     private $debug = [];
 
     /**
-     * @var OutputInterface
+     * @var Output
      */
     private $output;
 
     /**
      * Issuer constructor.
-     * @param OutputInterface $output
+     * @param Output $output
      */
     public function __construct(Output $output)
     {

--- a/src/Hal/Component/Tree/Graph.php
+++ b/src/Hal/Component/Tree/Graph.php
@@ -12,7 +12,7 @@ namespace Hal\Component\Tree;
 class Graph implements \Countable
 {
     /**
-     * @var array
+     * @var Node[]
      */
     private $datas = array();
 
@@ -81,7 +81,7 @@ class Graph implements \Countable
 
     /**
      * @param $key
-     * @return null
+     * @return Node|null
      */
     public function get($key)
     {

--- a/src/Hal/Metric/Class_/Coupling/ExternalsVisitor.php
+++ b/src/Hal/Metric/Class_/Coupling/ExternalsVisitor.php
@@ -21,7 +21,7 @@ class ExternalsVisitor extends NodeVisitorAbstract
     private $metrics;
 
     /**
-     * @var Stmt\Use_[]
+     * @var Stmt\UseUse[]
      */
     private $uses = [];
 

--- a/src/Hal/Metric/Metric.php
+++ b/src/Hal/Metric/Metric.php
@@ -8,6 +8,11 @@ namespace Hal\Metric;
 interface Metric
 {
     /**
+     * @return string
+     */
+    public function getName();
+
+    /**
      * @param $key
      * @return mixed
      */

--- a/src/Hal/Metric/Metrics.php
+++ b/src/Hal/Metric/Metrics.php
@@ -14,7 +14,7 @@ class Metrics implements \JsonSerializable
     private $data = [];
 
     /**
-     * @param $metric
+     * @param Metric $metric
      * @return $this
      */
     public function attach($metric)
@@ -25,7 +25,7 @@ class Metrics implements \JsonSerializable
 
     /**
      * @param $key
-     * @return null
+     * @return Metric|null
      */
     public function get($key)
     {

--- a/src/Hal/Report/Cli/Reporter.php
+++ b/src/Hal/Report/Cli/Reporter.php
@@ -15,14 +15,14 @@ class Reporter
     private $config;
 
     /**
-     * @var OutputInterface
+     * @var Output
      */
     private $output;
 
     /**
      * Reporter constructor.
      * @param Config $config
-     * @param OutputInterface $output
+     * @param Output $output
      */
     public function __construct(Config $config, Output $output)
     {

--- a/src/Hal/Report/Html/Reporter.php
+++ b/src/Hal/Report/Html/Reporter.php
@@ -90,8 +90,8 @@ class Reporter
             sprintf('%s/js/history-%d.json', $logDir, $next),
             json_encode($today, JSON_PRETTY_PRINT)
         );
-	file_put_contents(
-            sprintf('%s/js/latest.json', $logDir, $next),
+	    file_put_contents(
+            sprintf('%s/js/latest.json', $logDir),
             json_encode($today, JSON_PRETTY_PRINT)
         );
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -81,7 +81,7 @@ function iterate_over_node($node, $callback)
 
 /**
  * @param $node
- * @return string
+ * @return string|null
  */
 function getNameOfNode($node)
 {


### PR DESCRIPTION
Some types in  PHPDoc are outdated.

Also: I added a `getName()` method to the interface `Hal\Metric\Metric` because every Metric has it and it is used in the class `Hal\Metric\Metrics`.

Perhaps you might have a look at [Hal\Component\Tree\Operator\CycleDetector:46](https://github.com/phpmetrics/PhpMetrics/blob/master/src/Hal/Component/Tree/Operator/CycleDetector.php#L46)? I'm not sure about this line.