### PR TITLE
Fix name resolving of anonymous classes

### DIFF
--- a/src/Hal/Metric/Class_/ClassEnumVisitor.php
+++ b/src/Hal/Metric/Class_/ClassEnumVisitor.php
@@ -39,13 +39,7 @@ class ClassEnumVisitor extends NodeVisitorAbstract
                 $class->set('interface', true);
             } else {
 
-                if(null === $node->name) {
-                    // anonymous class
-                    $name = 'anonymous@' . spl_object_hash($node);
-                } else {
-                    $name = $node->namespacedName->toString();
-                }
-
+                $name = (string) (isset($node->namespacedName) ? $node->namespacedName : 'anonymous@'.spl_object_hash($node));
                 $class = new ClassMetric($name);
                 $class->set('interface', false);
             }

--- a/src/Hal/Metric/Class_/Complexity/CyclomaticComplexityVisitor.php
+++ b/src/Hal/Metric/Class_/Complexity/CyclomaticComplexityVisitor.php
@@ -46,8 +46,8 @@ class CyclomaticComplexityVisitor extends NodeVisitorAbstract
         if ($node instanceof Stmt\Class_
             || $node instanceof Stmt\Interface_
         ) {
-
-            $class = $this->metrics->get($node->namespacedName->toString());
+            $name = (string) (isset($node->namespacedName) ? $node->namespacedName : 'anonymous@'.spl_object_hash($node));
+            $class = $this->metrics->get($name);
 
             $ccn = 1;
             $ccnByMethod = array();

--- a/src/Hal/Metric/Class_/Complexity/KanDefectVisitor.php
+++ b/src/Hal/Metric/Class_/Complexity/KanDefectVisitor.php
@@ -36,8 +36,8 @@ class KanDefectVisitor extends NodeVisitorAbstract
         if ($node instanceof Stmt\Class_
             || $node instanceof Stmt\Interface_
         ) {
-
-            $class = $this->metrics->get($node->namespacedName->toString());
+            $name = (string) (isset($node->namespacedName) ? $node->namespacedName : 'anonymous@'.spl_object_hash($node));
+            $class = $this->metrics->get($name);
 
             $select = $while = $if = 0;
 

--- a/src/Hal/Metric/Class_/Component/MaintainabilityIndexVisitor.php
+++ b/src/Hal/Metric/Class_/Component/MaintainabilityIndexVisitor.php
@@ -50,7 +50,8 @@ class MaintainabilityIndexVisitor extends NodeVisitorAbstract
         if ($node instanceof Stmt\Class_) {
 
             if ($node instanceof Stmt\Class_) {
-                $classOrFunction = $this->metrics->get($node->namespacedName->toString());
+                $name = (string) (isset($node->namespacedName) ? $node->namespacedName : 'anonymous@'.spl_object_hash($node));
+                $classOrFunction = $this->metrics->get($name);
             } else {
                 $classOrFunction = new FunctionMetric($node->name);
                 $this->metrics->attach($classOrFunction);

--- a/src/Hal/Metric/Class_/Coupling/ExternalsVisitor.php
+++ b/src/Hal/Metric/Class_/Coupling/ExternalsVisitor.php
@@ -51,8 +51,8 @@ class ExternalsVisitor extends NodeVisitorAbstract
         if ($node instanceof Stmt\Class_
             || $node instanceof Stmt\Interface_
         ) {
-
-            $class = $this->metrics->get($node->namespacedName->toString());
+            $name = (string) (isset($node->namespacedName) ? $node->namespacedName : 'anonymous@'.spl_object_hash($node));
+            $class = $this->metrics->get($name);
             $nodeClass = $node;
 
             $dependencies = [];

--- a/src/Hal/Metric/Class_/Structural/LcomVisitor.php
+++ b/src/Hal/Metric/Class_/Structural/LcomVisitor.php
@@ -40,7 +40,8 @@ class LcomVisitor extends NodeVisitorAbstract
 
             // we build a graph of internal dependencies in class
             $graph = new Graph();
-            $class = $this->metrics->get($node->namespacedName->toString());
+            $name = (string) (isset($node->namespacedName) ? $node->namespacedName : 'anonymous@'.spl_object_hash($node));
+            $class = $this->metrics->get($name);
 
             foreach ($node->stmts as $stmt) {
                 if ($stmt instanceof Stmt\ClassMethod) {

--- a/src/Hal/Metric/Class_/Structural/SystemComplexityVisitor.php
+++ b/src/Hal/Metric/Class_/Structural/SystemComplexityVisitor.php
@@ -41,7 +41,8 @@ class SystemComplexityVisitor extends NodeVisitorAbstract
     {
         if ($node instanceof Stmt\Class_) {
 
-            $class = $this->metrics->get($node->namespacedName->toString());
+            $name = (string) (isset($node->namespacedName) ? $node->namespacedName : 'anonymous@'.spl_object_hash($node));
+            $class = $this->metrics->get($name);
 
             $sy = $dc = $sc = array();
 

--- a/src/Hal/Metric/Class_/Text/HalsteadVisitor.php
+++ b/src/Hal/Metric/Class_/Text/HalsteadVisitor.php
@@ -46,7 +46,8 @@ class HalsteadVisitor extends NodeVisitorAbstract
         if ($node instanceof Stmt\Class_ || $node instanceof Stmt\Function_) {
 
             if ($node instanceof Stmt\Class_) {
-                $classOrFunction = $this->metrics->get($node->namespacedName->toString());
+                $name = (string) (isset($node->namespacedName) ? $node->namespacedName : 'anonymous@'.spl_object_hash($node));
+                $classOrFunction = $this->metrics->get($name);
             } else {
                 $classOrFunction = new FunctionMetric($node->name);
                 $this->metrics->attach($classOrFunction);

--- a/src/Hal/Metric/Class_/Text/LengthVisitor.php
+++ b/src/Hal/Metric/Class_/Text/LengthVisitor.php
@@ -37,7 +37,8 @@ class LengthVisitor extends NodeVisitorAbstract
         if ($node instanceof Stmt\Class_ || $node instanceof Stmt\Function_) {
 
             if ($node instanceof Stmt\Class_) {
-                $classOrFunction = $this->metrics->get($node->namespacedName->toString());
+                $name = (string) (isset($node->namespacedName) ? $node->namespacedName : 'anonymous@'.spl_object_hash($node));
+                $classOrFunction = $this->metrics->get($name);
             } else {
                 $classOrFunction = new FunctionMetric($node->name);
                 $this->metrics->attach($classOrFunction);


### PR DESCRIPTION
While I'm no fan of global functions, the name resolving perhaps should be moved to one. Can `getNameOfNode()` be used for this?

Fixes #280
See also #266 and bc1ec95ef83a5b220d26dbfca6c29875a80efa7c