### PR TITLE
Allow // in text without counting it as comment

### DIFF
--- a/src/Hal/Metric/Class_/Text/LengthVisitor.php
+++ b/src/Hal/Metric/Class_/Text/LengthVisitor.php
@@ -60,8 +60,12 @@ class LengthVisitor extends NodeVisitorAbstract
             $code = preg_replace('!/\*.*?\*/!s', '', $code);
 
             // count and remove single line comments
-            $code = preg_replace('!(\s*?//.+\n)!', "\n", $code, -1, $nbCommentsSingleLine);
-            $cloc += $nbCommentsSingleLine;
+            $code = preg_replace_callback('!(\'[^\']*\'|"[^"]*")|((?:#|\/\/).*$)!m', function (array $matches) use (&$cloc) {
+                if (isset($matches[2])) {
+                    $cloc += 1;
+                }
+                return $matches[1];
+            }, $code, -1);
 
             // count and remove empty lines
             $code = trim(preg_replace('!(^\s*[\r\n])!sm', '', $code));

--- a/tests/Metric/Class_/Text/LengthVisitorTest.php
+++ b/tests/Metric/Class_/Text/LengthVisitorTest.php
@@ -2,10 +2,8 @@
 namespace Test\Hal\Metric\Class_\Structural;
 
 use Hal\Metric\Class_\ClassEnumVisitor;
-use Hal\Metric\Class_\Text\HalsteadVisitor;
 use Hal\Metric\Class_\Text\LengthVisitor;
 use Hal\Metric\Metrics;
-use PhpParser\Lexer;
 use PhpParser\ParserFactory;
 
 /**
@@ -18,7 +16,7 @@ class LengthVisitorTest extends \PHPUnit_Framework_TestCase {
     /**
      * @dataProvider provideExamples
      */
-    public function testLackOfCohesionOfMethodsIsWellCalculated($example, $functionName, $loc, $lloc, $cloc)
+    public function testLineCountsAreWellCalculated($example, $functionName, $loc, $lloc, $cloc)
     {
         $metrics = new Metrics();
 
@@ -41,7 +39,7 @@ class LengthVisitorTest extends \PHPUnit_Framework_TestCase {
     public function provideExamples()
     {
         return [
-            [ __DIR__.'/../../examples/loc1.php', 'A', 18, 11, 7],
+            [ __DIR__.'/../../examples/loc1.php', 'A', 21, 13, 8],
         ];
     }
 

--- a/tests/Metric/examples/loc1.php
+++ b/tests/Metric/examples/loc1.php
@@ -14,6 +14,8 @@ class A {
         $x = 1 + 1;
         $x = 1 + 1;
         $x = 1 + 1;
+        $x = 1 + 1; // a command in a line
+        echo 'http://phpmetrics.org/';
         return $x;
     }
 }


### PR DESCRIPTION
Resolves #273

Note: The PrettyPrinter reformats the code a little bit:

```diff
-class A {
-
+class A
+{
    /**
     * This a long comment
     *
     * @return int
     */
    public function x()
    {
        // any comment
        // another comment
        $x = 1 + 1;
        $x = 1 + 1;
        $x = 1 + 1;
-       $x = 1 + 1; // a command in a line
+       $x = 1 + 1;
+       // a command in a line
        echo 'http://phpmetrics.org/';
        return $x;
    }
}
```
As you can see it moves inline comments into its own line (which explains why the `$loc` in the test increased by 3 instead of 2).
Relying on this would allow us to fix #273 more easily (which is closer to the current implementation):
```php
$code = preg_replace('!^(\s*//.+)!m', "\n", $code, -1, $nbCommentsSingleLine);
$cloc += $nbCommentsSingleLine;
```
But I'm not sure, whether we can trust the PrettyPrinter to always place inline comments on its own line.
