### PR TITLE
add preg_quote around dir

### DIFF
--- a/src/Hal/Component/File/Finder.php
+++ b/src/Hal/Component/File/Finder.php
@@ -77,7 +77,7 @@ class Finder
 
                 $filterRegex = sprintf(
                     '`^%s%s$`',
-                    !empty($this->excludedDirs) ? '((?!' . implode('|', $this->excludedDirs) . ').)+' : '.+',
+                    !empty($this->excludedDirs) ? '((?!' . preg_quote(implode('|', $this->excludedDirs)) . ').)+' : '.+',
                     '\.(' . implode('|', $this->extensions) . ')'
                 );
 


### PR DESCRIPTION
Test case: `--excluded-dirs="test|php|test|*.views.inc|*.features.inc"`
It gets converted to: `"`^((?!test|php|test|*.views.inc|*.features.inc).)+\.(php)$`"`

Which produce the following error:

```
  [InvalidArgumentException]
  RegexIterator::__construct(): Compilation failed: nothing to repeat at offset 19
```

The string should be preg quoted befor to pass the regexp machine.