### PR TITLE
Bugfix: preventing duplicate edges from appearing in a graph when analyzing

### DIFF
--- a/src/Hal/Component/Tree/GraphDeduplicated.php
+++ b/src/Hal/Component/Tree/GraphDeduplicated.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Hal\Component\Tree;
+
+class GraphDeduplicated extends Graph
+{
+    /**
+     * @var array list of already present edges in this graph
+     */
+    private $edgesMap = [];
+
+    /**
+     * @param Node $from
+     * @param Node $to
+     *
+     * @return $this
+     */
+    public function addEdge(Node $from, Node $to)
+    {
+        $key = $from->getUniqueId().'->'.$to->getUniqueId();
+
+        if (isset($this->edgesMap[$key])) {
+            return $this;
+        }
+
+        $this->edgesMap[$key] = true;
+
+        return parent::addEdge($from, $to);
+    }
+}

--- a/src/Hal/Component/Tree/Node.php
+++ b/src/Hal/Component/Tree/Node.php
@@ -109,4 +109,11 @@ class Node
         return $this;
     }
 
+    /**
+     * @return string Unique id for this node independent of class name or node type
+     */
+    public function getUniqueId()
+    {
+        return spl_object_hash($this);
+    }
 }

--- a/src/Hal/Metric/Class_/Structural/LcomVisitor.php
+++ b/src/Hal/Metric/Class_/Structural/LcomVisitor.php
@@ -1,7 +1,7 @@
 <?php
 namespace Hal\Metric\Class_\Structural;
 
-use Hal\Component\Tree\Graph;
+use Hal\Component\Tree\GraphDeduplicated;
 use Hal\Component\Tree\Node as TreeNode;
 use Hal\Metric\Helper\MetricClassNameGenerator;
 use Hal\Metric\Metrics;
@@ -40,7 +40,7 @@ class LcomVisitor extends NodeVisitorAbstract
         if ($node instanceof Stmt\Class_) {
 
             // we build a graph of internal dependencies in class
-            $graph = new Graph();
+            $graph = new GraphDeduplicated();
             $class = $this->metrics->get(MetricClassNameGenerator::getName($node));
 
             foreach ($node->stmts as $stmt) {

--- a/src/Hal/Metric/System/Coupling/Coupling.php
+++ b/src/Hal/Metric/System/Coupling/Coupling.php
@@ -2,7 +2,7 @@
 
 namespace Hal\Metric\System\Coupling;
 
-use Hal\Component\Tree\Graph;
+use Hal\Component\Tree\GraphDeduplicated;
 use Hal\Component\Tree\Node;
 use Hal\Metric\ClassMetric;
 use Hal\Metric\Metrics;
@@ -22,7 +22,7 @@ class Coupling
     {
 
         // build a graph of relations
-        $graph = new Graph();
+        $graph = new GraphDeduplicated();
 
         foreach ($metrics->all() as $metric) {
             if (!$metric instanceof ClassMetric) {

--- a/src/Hal/Metric/System/Coupling/DepthOfInheritanceTree.php
+++ b/src/Hal/Metric/System/Coupling/DepthOfInheritanceTree.php
@@ -2,7 +2,7 @@
 
 namespace Hal\Metric\System\Coupling;
 
-use Hal\Component\Tree\Graph;
+use Hal\Component\Tree\GraphDeduplicated;
 use Hal\Component\Tree\Node;
 use Hal\Component\Tree\Operator\SizeOfTree;
 use Hal\Metric\ClassMetric;
@@ -27,7 +27,7 @@ class DepthOfInheritanceTree
         $projectMetric = new ProjectMetric('tree');
 
         // building graph with parents / childs relations only
-        $graph = new Graph();
+        $graph = new GraphDeduplicated();
 
         foreach ($metrics->all() as $metric) {
             if (!$metric instanceof ClassMetric) {

--- a/tests/Component/Tree/GraphDeduplicatedTest.php
+++ b/tests/Component/Tree/GraphDeduplicatedTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Test;
+
+use Hal\Component\Tree\Graph;
+use Hal\Component\Tree\GraphDeduplicated;
+use Hal\Component\Tree\Node;
+
+/**
+ * @group tree
+ */
+class GraphDeduplicatedTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testEdgeDeduplication()
+    {
+        $graph = new GraphDeduplicated();
+        $a = new Node('A');
+        $b = new Node('B');
+        $graph->insert($a);
+        $graph->insert($b);
+
+        $graph->addEdge($a, $b);
+        $graph->addEdge($a, $b);
+        $this->assertCount(1, $graph->getEdges());
+
+        $graph->addEdge($b, $a);
+        $this->assertCount(2, $graph->getEdges());
+    }
+}


### PR DESCRIPTION
This fixes a problem #291 and hopefully some others.

I've added a check if an edge already exists in a graph before adding it in analyses. I've decided to leave a possibility to have a graph with duplicate edges just in case (though such ones are very rare)