### PR TITLE
Add installed package column when composer.lock file is found.

### DIFF
--- a/src/Hal/Component/File/Finder.php
+++ b/src/Hal/Component/File/Finder.php
@@ -91,7 +91,7 @@ class Finder
                     $files[] = $file[0];
                 }
             } elseif (is_file($path)) {
-                $files = array($path);
+                $files[] = $path;
             }
         }
         return $files;

--- a/src/Hal/Metric/System/Packages/Composer/Composer.php
+++ b/src/Hal/Metric/System/Packages/Composer/Composer.php
@@ -33,30 +33,12 @@ class Composer
      */
     public function calculate(Metrics $metrics)
     {
-
         $projectMetric = new ProjectMetric('composer');
         $projectMetric->set('packages', []);
         $metrics->attach($projectMetric);
         $packages = [];
-        $rawRequirements = [];
-
-        // find composer.json files
-        $finder = new Finder(['json'], $this->config->get('exclude'));
-        $files = $finder->fetch($this->config->get('files'));
-
-        foreach ($files as $filename) {
-
-            if (!preg_match('/composer\.json|composer-dist\.json/', $filename)) {
-                continue;
-            }
-            $datas = (object)json_decode(file_get_contents($filename));
-
-            if (!isset($datas->require)) {
-                continue;
-            }
-
-            $rawRequirements = array_merge($rawRequirements, (array)$datas->require);
-        }
+        $rawRequirements = $this->getComposerJsonRequirements();
+        $rawInstalled = $this->getComposerLockInstalled(\array_keys($rawRequirements));
 
         $packagist = new Packagist();
         foreach ($rawRequirements as $requirement => $version) {
@@ -66,6 +48,7 @@ class Composer
             $packages[$requirement] = (object)array(
                 'name' => $requirement,
                 'required' => $version,
+                'installed' => isset($rawInstalled[$requirement]) ? $rawInstalled[$requirement] : null,
                 'latest' => $package->latest,
                 'license' => $package->license,
                 'homepage' => $package->homepage,
@@ -74,5 +57,73 @@ class Composer
         }
 
         $projectMetric->set('packages', $packages);
+        $projectMetric->set('packages-installed', $rawInstalled);
+    }
+
+    /**
+     * Returns the requirements defined in the composer(-dist)?.json file.
+     * @return array
+     */
+    protected function getComposerJsonRequirements()
+    {
+        $rawRequirements = [[]];
+
+        // find composer.json files
+        $finder = new Finder(['json'], $this->config->get('exclude'));
+        $files = $finder->fetch($this->config->get('files'));
+
+        foreach ($files as $filename) {
+            if (!\preg_match('/composer(-dist)?\.json/', $filename)) {
+                continue;
+            }
+            $composerJson = (object)\json_decode(\file_get_contents($filename));
+
+            if (!isset($composerJson->require)) {
+                continue;
+            }
+
+            $rawRequirements[] = (array)$composerJson->require;
+        }
+
+        return \call_user_func_array('array_merge', $rawRequirements);
+    }
+
+    /**
+     * Returns the installed packages from the composer.lock file.
+     * @param array $rootPackageRequirements List of requirements to match installed packages only with requirements.
+     * @return array
+     */
+    protected function getComposerLockInstalled($rootPackageRequirements)
+    {
+        $rawInstalled = [[]];
+
+        // Find composer.lock file
+        $finder = new Finder(['lock'], $this->config->get('exclude'));
+        $files = $finder->fetch($this->config->get('files'));
+
+        // List all composer.lock found in the project.
+        foreach ($files as $filename) {
+            if (false === \strpos($filename, 'composer.lock')) {
+                continue;
+            }
+            $composerLockJson = (object)\json_decode(\file_get_contents($filename));
+
+            if (!isset($composerLockJson->packages)) {
+                continue;
+            }
+
+            $installed = [];
+            foreach ($composerLockJson->packages as $package) {
+                if (!\in_array($package->name, $rootPackageRequirements, true)) {
+                    continue;
+                }
+
+                $installed[$package->name] = \preg_replace('#[^.\d]#', '', $package->version);
+            }
+
+            $rawInstalled[] = $installed;
+        }
+
+        return \call_user_func_array('array_merge', $rawInstalled);
     }
 }

--- a/src/Hal/Report/Html/template/index.php
+++ b/src/Hal/Report/Html/template/index.php
@@ -122,10 +122,14 @@
                 <div class="clusterize small">
                     <div id="clusterizePackages" class="clusterize-scroll">
                         <table>
+                            <?php
+                            $packagesInstalled = isset($project['composer']['packages-installed']) ? $project['composer']['packages-installed'] : [];
+                            ?>
                             <thead>
                             <tr>
                                 <th>Package</th>
                                 <th>Required</th>
+                                <?php if (0 !== count($packagesInstalled)) {?><th>Installed</th><?php } ?>
                                 <th>Latest</th>
                                 <th>License</th>
                             </tr>
@@ -137,20 +141,24 @@
                                 return strcmp($a->name, $b->name);
                             });
                             foreach ($packages as $package) { ?>
-                                <tr>
+                                <tr<?php if (null !== $package->installed && $package->installed !== $package->latest) { echo ' style="color:orangered"'; }?>>
                                     <td><?php echo $package->name; ?></td>
                                     <td><?php echo $package->required; ?></td>
+                                    <?php if (0 !== count($packagesInstalled)) {?><td><?php echo $package->installed; ?></td><?php } ?>
                                     <td><?php echo $package->latest; ?></td>
                                     <td><?php foreach($package->license as $license) { ?>
                                             <a target="_blank" href="https://spdx.org/licenses/<?php echo $license;?>.html"><?php echo $license;?></a>
-                                        <?php }; ?>
+                                        <?php } ?>
                                     </td>
                                 </tr>
                             <?php } ?>
                             </tbody>
                         </table>
-                        <?php if(0 === sizeof($packages)) { ?>
+                        <?php if(0 === count($packages)) { ?>
                             <div>No composer.json file found</div>
+                        <?php } ?>
+                        <?php if(0 === count($packagesInstalled)) { ?>
+                            <div>No composer.lock file found</div>
                         <?php } ?>
                     </div>
                 </div>


### PR DESCRIPTION
This PR fixes #284 And trouble when listing several files (not folders) to parse with PhpMetrics.