### PR TITLE
Add dockerfile in project to use the latest phar.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+*
+!releases/phpmetrics.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,12 @@ matrix:
   - php: hhvm
   - php: hhvm-nightly
 
+services:
+  - docker
+
+install:
+  - docker build -t test_phpmetrics .
+
 before_script:
   - composer selfupdate --quiet
   - composer install --prefer-dist --no-interaction --no-progress
@@ -25,6 +31,7 @@ before_script:
 
 script:
   - make test
+  - docker run --rm test_phpmetrics
 
 before_deploy:
   - make build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM php:7.1
+
+MAINTAINER "niconoe-" <nicolas.giraud.dev@gmail.com>
+
+COPY releases/phpmetrics.phar /usr/local/bin/phpmetrics
+
+RUN chmod +x /usr/local/bin/phpmetrics \
+    # Install git to be able to use option "--git".
+    && apt-get update && apt-get install -y git \
+    && rm -rf /var/cache/apk/* /var/tmp/* /tmp/*
+
+VOLUME ["/app"]
+WORKDIR /app
+
+ENTRYPOINT ["phpmetrics"]
+CMD ["--version"]


### PR DESCRIPTION
Fixes #244 and add also installation of `git` in the image to use the option "--git" safely.

Running a test_phpmetrics image creation in Travis to test the state of the container.