### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "nikic/php-parser": "v3.*"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=4.8.27,<=5.7.13"
+        "phpunit/phpunit": ">=4.8.35,<=5.7.13"
     },
     "bin": [
         "bin/phpmetrics"

--- a/tests/Application/Config/File/ConfigFileReaderTest.php
+++ b/tests/Application/Config/File/ConfigFileReaderTest.php
@@ -2,7 +2,9 @@
 
 use Hal\Application\Config\File\ConfigFileReaderInterface;
 
-class ConfigFileReaderTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ConfigFileReaderTest extends TestCase
 {
     public function testJsonConfigFile()
     {

--- a/tests/Application/Config/ParserTest.php
+++ b/tests/Application/Config/ParserTest.php
@@ -2,12 +2,13 @@
 namespace Test\Hal\Application\Config;
 
 use Hal\Application\Config\Parser;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group application
  * @group config
  */
-class ParserTest extends \PHPUnit_Framework_TestCase
+class ParserTest extends TestCase
 {
     /**
      * @dataProvider providesExample

--- a/tests/Component/File/FinderTest.php
+++ b/tests/Component/File/FinderTest.php
@@ -3,11 +3,12 @@
 namespace Test\Hal\Component\File;
 
 use Hal\Component\File\Finder;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group file
  */
-class FinderTest extends \PHPUnit_Framework_TestCase
+class FinderTest extends TestCase
 {
 
     public function testPathsGivenAreRecoveredOverExcluded()

--- a/tests/Component/Issuer/IssuerTest.php
+++ b/tests/Component/Issuer/IssuerTest.php
@@ -41,7 +41,7 @@ class IssuerTest extends \PHPUnit_Framework_TestCase
 <?php
 class A{
    public function foo() {
-   
+
    }
 }
 EOT;

--- a/tests/Component/Tree/GraphDeduplicatedTest.php
+++ b/tests/Component/Tree/GraphDeduplicatedTest.php
@@ -5,11 +5,12 @@ namespace Test;
 use Hal\Component\Tree\Graph;
 use Hal\Component\Tree\GraphDeduplicated;
 use Hal\Component\Tree\Node;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group tree
  */
-class GraphDeduplicatedTest extends \PHPUnit_Framework_TestCase
+class GraphDeduplicatedTest extends TestCase
 {
 
     public function testEdgeDeduplication()

--- a/tests/Component/Tree/GraphTest.php
+++ b/tests/Component/Tree/GraphTest.php
@@ -6,11 +6,12 @@ use Hal\Component\Tree\Graph;
 use Hal\Component\Tree\GraphFactory;
 use Hal\Component\Tree\HashMap;
 use Hal\Component\Tree\Node;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group tree
  */
-class GraphTest extends \PHPUnit_Framework_TestCase {
+class GraphTest extends TestCase {
 
     public function testICanAddEdge() {
         $graph = new Graph();

--- a/tests/Component/Tree/HashMapTest.php
+++ b/tests/Component/Tree/HashMapTest.php
@@ -5,11 +5,12 @@ use Hal\Component\Token\Token;
 use Hal\Component\Token\Tokenizer;
 use Hal\Component\Tree\HashMap;
 use Hal\Component\Tree\Node;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group tree
  */
-class HashMapTest extends \PHPUnit_Framework_TestCase {
+class HashMapTest extends TestCase {
 
     public function testICanWorkWithHashMap() {
 

--- a/tests/Component/Tree/NodeTest.php
+++ b/tests/Component/Tree/NodeTest.php
@@ -4,11 +4,12 @@ namespace Test;
 
 use Hal\Component\Tree\Edge;
 use Hal\Component\Tree\Node;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group tree
  */
-class NodeTest extends \PHPUnit_Framework_TestCase {
+class NodeTest extends TestCase {
 
     public function testICanWorkWithNode() {
 

--- a/tests/Component/Tree/Operator/CycleDetectorTest.php
+++ b/tests/Component/Tree/Operator/CycleDetectorTest.php
@@ -7,11 +7,12 @@ use Hal\Component\Tree\GraphFactory;
 use Hal\Component\Tree\HashMap;
 use Hal\Component\Tree\Node;
 use Hal\Component\Tree\Operator\CycleDetector;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group tree
  */
-class CycleDetectorTest extends \PHPUnit_Framework_TestCase {
+class CycleDetectorTest extends TestCase {
 
     public function testCycleIsDetected()
     {

--- a/tests/Component/Tree/Operator/SizeOfTreeTest.php
+++ b/tests/Component/Tree/Operator/SizeOfTreeTest.php
@@ -6,11 +6,12 @@ use Hal\Component\Tree\Graph;
 use Hal\Component\Tree\GraphFactory;
 use Hal\Component\Tree\Node;
 use Hal\Component\Tree\Operator\SizeOfTree;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group tree
  */
-class SizeOfTreeTest extends \PHPUnit_Framework_TestCase
+class SizeOfTreeTest extends TestCase
 {
 
     /**

--- a/tests/Metric/Class_/ClassEnumVisitorTest.php
+++ b/tests/Metric/Class_/ClassEnumVisitorTest.php
@@ -4,11 +4,12 @@ namespace Test\Hal\Metric\Class_;
 use Hal\Metric\Class_\ClassEnumVisitor;
 use Hal\Metric\Metrics;
 use PhpParser\ParserFactory;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group class
  */
-class ClassEnumVisitorTest extends \PHPUnit_Framework_TestCase
+class ClassEnumVisitorTest extends TestCase
 {
 
 

--- a/tests/Metric/Class_/Complexity/CyclomaticComplexityVisitorTest.php
+++ b/tests/Metric/Class_/Complexity/CyclomaticComplexityVisitorTest.php
@@ -6,8 +6,9 @@ use Hal\Metric\Class_\Complexity\CyclomaticComplexityVisitor;
 use Hal\Metric\Class_\Complexity\McCabeVisitor;
 use Hal\Metric\Metrics;
 use PhpParser\ParserFactory;
+use PHPUnit\Framework\TestCase;
 
-class CyclomaticComplexityVisitorTest extends \PHPUnit_Framework_TestCase {
+class CyclomaticComplexityVisitorTest extends TestCase {
 
 
     /**

--- a/tests/Metric/Class_/Complexity/KanDefectVisitorTest.php
+++ b/tests/Metric/Class_/Complexity/KanDefectVisitorTest.php
@@ -7,13 +7,14 @@ use Hal\Metric\Class_\Complexity\KanDefectVisitor;
 use Hal\Metric\Class_\Complexity\McCabeVisitor;
 use Hal\Metric\Metrics;
 use PhpParser\ParserFactory;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group metric
  * @group kan
  * @group defect
  */
-class KanDefectVisitorTest extends \PHPUnit_Framework_TestCase {
+class KanDefectVisitorTest extends TestCase {
 
 
     /**

--- a/tests/Metric/Class_/Complexity/SystemComplexityVisitorTest.php
+++ b/tests/Metric/Class_/Complexity/SystemComplexityVisitorTest.php
@@ -6,13 +6,14 @@ use Hal\Metric\Class_\Complexity\McCabeVisitor;
 use Hal\Metric\Class_\Structural\SystemComplexityVisitor;
 use Hal\Metric\Metrics;
 use PhpParser\ParserFactory;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group metric
  * @group complexity
  * @group defect
  */
-class SystemComplexityVisitorTest extends \PHPUnit_Framework_TestCase
+class SystemComplexityVisitorTest extends TestCase
 {
 
 

--- a/tests/Metric/Class_/Component/MaintainabilityIndexVisitorTest.php
+++ b/tests/Metric/Class_/Component/MaintainabilityIndexVisitorTest.php
@@ -4,13 +4,14 @@ namespace Test\Hal\Metric\Class_\Structural;
 use Hal\Metric\Class_\Component\MaintainabilityIndexVisitor;
 use Hal\Metric\Metrics;
 use PhpParser\ParserFactory;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group metric
  * @group mi
  * @group complex
  */
-class MaintainabilityIndexVisitorTest extends \PHPUnit_Framework_TestCase {
+class MaintainabilityIndexVisitorTest extends TestCase {
 
 
     /**
@@ -44,7 +45,7 @@ class MaintainabilityIndexVisitorTest extends \PHPUnit_Framework_TestCase {
         $code = <<<EOT
 <?php class A {
     public function foo() {
-    
+
     }
 }
 EOT;

--- a/tests/Metric/Class_/Coupling/ExternalsVisitorTest.php
+++ b/tests/Metric/Class_/Coupling/ExternalsVisitorTest.php
@@ -6,13 +6,14 @@ use Hal\Metric\Class_\Complexity\McCabeVisitor;
 use Hal\Metric\Class_\Coupling\ExternalsVisitor;
 use Hal\Metric\Metrics;
 use PhpParser\ParserFactory;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group metric
  * @group externals
  * @group coupling
  */
-class ExternalsVisitorTest extends \PHPUnit_Framework_TestCase {
+class ExternalsVisitorTest extends TestCase {
 
 
     /**

--- a/tests/Metric/Class_/Structural/LcomVisitorTest.php
+++ b/tests/Metric/Class_/Structural/LcomVisitorTest.php
@@ -5,8 +5,9 @@ use Hal\Metric\Class_\ClassEnumVisitor;
 use Hal\Metric\Class_\Structural\LcomVisitor;
 use Hal\Metric\Metrics;
 use PhpParser\ParserFactory;
+use PHPUnit\Framework\TestCase;
 
-class LcomVisitorTest extends \PHPUnit_Framework_TestCase {
+class LcomVisitorTest extends TestCase {
 
 
     /**

--- a/tests/Metric/Class_/Text/HalsteadVisitorTest.php
+++ b/tests/Metric/Class_/Text/HalsteadVisitorTest.php
@@ -5,12 +5,13 @@ use Hal\Metric\Class_\ClassEnumVisitor;
 use Hal\Metric\Class_\Text\HalsteadVisitor;
 use Hal\Metric\Metrics;
 use PhpParser\ParserFactory;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group halstead
  * @group metric
  */
-class HalsteadVisitorTest extends \PHPUnit_Framework_TestCase {
+class HalsteadVisitorTest extends TestCase {
 
 
     /**

--- a/tests/Metric/Class_/Text/LengthVisitorTest.php
+++ b/tests/Metric/Class_/Text/LengthVisitorTest.php
@@ -5,12 +5,13 @@ use Hal\Metric\Class_\ClassEnumVisitor;
 use Hal\Metric\Class_\Text\LengthVisitor;
 use Hal\Metric\Metrics;
 use PhpParser\ParserFactory;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group loc
  * @group metric
  */
-class LengthVisitorTest extends \PHPUnit_Framework_TestCase {
+class LengthVisitorTest extends TestCase {
 
 
     /**

--- a/tests/Metric/Helper/RoleOfMethodDetectorTest.php
+++ b/tests/Metric/Helper/RoleOfMethodDetectorTest.php
@@ -5,13 +5,14 @@ use Hal\Metric\Helper\RoleOfMethodDetector;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\ParserFactory;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group method
  * @group helper
  * @group parsing
  */
-class RoleOfMethodDetectorTest extends \PHPUnit_Framework_TestCase
+class RoleOfMethodDetectorTest extends TestCase
 {
 
     /**

--- a/tests/Metric/System/UnitTesting/UnitTestingTest.php
+++ b/tests/Metric/System/UnitTesting/UnitTestingTest.php
@@ -4,11 +4,12 @@ namespace Test\Hal\Metric\System\UnitTesting;
 use Hal\Application\Config\Config;
 use Hal\Metric\Metrics;
 use Hal\Metric\System\UnitTesting\UnitTesting;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group unit
  */
-class UnitTestingTest extends \PHPUnit_Framework_TestCase
+class UnitTestingTest extends TestCase
 {
 
     public function testICanParseJunitXmlFile() {

--- a/tests/Violation/Class_/BlobTest.php
+++ b/tests/Violation/Class_/BlobTest.php
@@ -3,11 +3,12 @@ namespace Test\Hal\Violation\Class_;
 
 use Hal\Violation\Class_\Blob;
 use Hal\Violation\Violations;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group violation
  */
-class BlobTest extends \PHPUnit_Framework_TestCase
+class BlobTest extends TestCase
 {
     /**
      * @dataProvider provideExamples

--- a/tests/binary/BinTest.php
+++ b/tests/binary/BinTest.php
@@ -1,10 +1,12 @@
 <?php
 namespace Test\Binary;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group binary
  */
-class BinFileTest extends \PHPUnit_Framework_TestCase
+class BinFileTest extends TestCase
 {
     private $phar;
 

--- a/tests/binary/PharTest.php
+++ b/tests/binary/PharTest.php
@@ -1,10 +1,12 @@
 <?php
 namespace Test\Binary;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group binary
  */
-class PharTest extends \PHPUnit_Framework_TestCase
+class PharTest extends TestCase
 {
     private $phar;
 

--- a/tests/binary/ReportTest.php
+++ b/tests/binary/ReportTest.php
@@ -1,10 +1,12 @@
 <?php
 namespace Test\Binary;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group binary
  */
-class BinReportTest extends \PHPUnit_Framework_TestCase
+class BinReportTest extends TestCase
 {
     private $phar;
 


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.