### PR TITLE
Improve composer package version comparison

### DIFF
--- a/src/Hal/Metric/System/Packages/Composer/Packagist.php
+++ b/src/Hal/Metric/System/Packages/Composer/Packagist.php
@@ -37,8 +37,10 @@ class Packagist
         // get latest version
         $latest = '0.0.0';
         foreach ((array)$json->package->versions as $version => $datas) {
-            $version = preg_replace('([^\.\d])', '', $version);
-            if (!preg_match('!\d+\.\d+\.\d+!', $version)) {
+            if ($version[0] === 'v') {
+                $version = substr($version, 1);
+            }
+            if (!preg_match('#^[\.\d]+$#', $version)) {
                 continue;
             }
             if ($compare = version_compare($version, $latest) == 1) {

--- a/src/Hal/Report/Html/template/index.php
+++ b/src/Hal/Report/Html/template/index.php
@@ -141,7 +141,7 @@
                                 return strcmp($a->name, $b->name);
                             });
                             foreach ($packages as $package) { ?>
-                                <tr<?php if (null !== $package->installed && $package->installed !== $package->latest) { echo ' style="color:orangered"'; }?>>
+                                <tr<?php if (null !== $package->installed && version_compare($package->installed, $package->latest) === -1) { echo ' style="color:orangered"'; }?>>
                                     <td><?php echo $package->name; ?></td>
                                     <td><?php echo $package->required; ?></td>
                                     <?php if (0 !== count($packagesInstalled)) {?><td><?php echo $package->installed; ?></td><?php } ?>


### PR DESCRIPTION
We assume that installed version should be compared to the latest
stable version of the package and not to beta, rc, ...
Hence, installed version in the next RC version (or beta or whatever)
should not be listed as old (color orangered)