### PR TITLE
Change the calculation of cyclomatic complexity

### DIFF
--- a/src/Hal/Metric/Class_/Complexity/CyclomaticComplexityVisitor.php
+++ b/src/Hal/Metric/Class_/Complexity/CyclomaticComplexityVisitor.php
@@ -1,7 +1,6 @@
 <?php
 namespace Hal\Metric\Class_\Complexity;
 
-use Hal\Component\Reflected\Method;
 use Hal\Metric\Helper\MetricClassNameGenerator;
 use Hal\Metric\Metrics;
 use PhpParser\Node;
@@ -24,31 +23,22 @@ use PhpParser\NodeVisitorAbstract;
  */
 class CyclomaticComplexityVisitor extends NodeVisitorAbstract
 {
-
     /**
      * @var Metrics
      */
     private $metrics;
 
-    /**
-     * ClassEnumVisitor constructor.
-     * @param Metrics $metrics
-     */
     public function __construct(Metrics $metrics)
     {
         $this->metrics = $metrics;
     }
 
-    /**
-     * @inheritdoc
-     */
     public function leaveNode(Node $node)
     {
         if ($node instanceof Stmt\Class_
             || $node instanceof Stmt\Interface_
             || $node instanceof Stmt\Trait_
         ) {
-
             $class = $this->metrics->get(MetricClassNameGenerator::getName($node));
 
             $ccn = 1;
@@ -62,9 +52,9 @@ class CyclomaticComplexityVisitor extends NodeVisitorAbstract
                         $ccn = 0;
 
                         foreach (get_object_vars($node) as $name => $member) {
-                            foreach (is_array($member) ? $member : [$member] as $member_item) {
-                                if ($member_item instanceof Node) {
-                                    $ccn += $cb($member_item);
+                            foreach (is_array($member) ? $member : [$member] as $memberItem) {
+                                if ($memberItem instanceof Node) {
+                                    $ccn += $cb($memberItem);
                                 }
                             }
                         }
@@ -78,18 +68,23 @@ class CyclomaticComplexityVisitor extends NodeVisitorAbstract
                             case $node instanceof Stmt\Do_:
                             case $node instanceof Node\Expr\BinaryOp\LogicalAnd:
                             case $node instanceof Node\Expr\BinaryOp\LogicalOr:
+                            case $node instanceof Node\Expr\BinaryOp\LogicalXor:
                             case $node instanceof Node\Expr\BinaryOp\BooleanAnd:
                             case $node instanceof Node\Expr\BinaryOp\BooleanOr:
-                            case $node instanceof Node\Expr\BinaryOp\Spaceship:
-                            case $node instanceof Stmt\Case_: // include default
                             case $node instanceof Stmt\Catch_:
-                            case $node instanceof Stmt\Continue_:
-                                $ccn++;
-                                break;
                             case $node instanceof Node\Expr\Ternary:
                             case $node instanceof Node\Expr\BinaryOp\Coalesce:
-                                $ccn = $ccn + 2;
+                                $ccn++;
                                 break;
+                            case $node instanceof Stmt\Case_: // include default
+                                if ($node->cond !== null) { // exclude default
+                                    $ccn++;
+                                }
+                                break;
+                            case $node instanceof Node\Expr\BinaryOp\Spaceship:
+                                $ccn += 2;
+                                break;
+
                         }
                         return $ccn;
                     };

--- a/tests/Metric/Class_/Complexity/CyclomaticComplexityVisitorTest.php
+++ b/tests/Metric/Class_/Complexity/CyclomaticComplexityVisitorTest.php
@@ -53,9 +53,14 @@ class CyclomaticComplexityVisitorTest extends \PHPUnit_Framework_TestCase {
     public function provideExamplesForClasses()
     {
         return [
-            [ __DIR__.'/../../examples/cyclomatic1.php', 'A', 8],
-            [ __DIR__.'/../../examples/cyclomatic1.php', 'B', 5],
-            [ __DIR__.'/../../examples/cyclomatic_anon.php', 'Foo\C', 1],
+            'A' => [ __DIR__.'/../../examples/cyclomatic1.php', 'A', 8],
+            'B' => [ __DIR__.'/../../examples/cyclomatic1.php', 'B', 4],
+            'Foo\\C' => [ __DIR__.'/../../examples/cyclomatic_anon.php', 'Foo\\C', 1],
+            'SwitchCase' => [ __DIR__.'/../../examples/cyclomatic_full.php', 'SwitchCase', 4],
+            'IfElseif' => [ __DIR__.'/../../examples/cyclomatic_full.php', 'IfElseif', 7],
+            'Loops' => [ __DIR__.'/../../examples/cyclomatic_full.php', 'Loops', 5],
+            'CatchIt' => [ __DIR__.'/../../examples/cyclomatic_full.php', 'CatchIt', 3],
+            'Logical' => [ __DIR__.'/../../examples/cyclomatic_full.php', 'Logical', 11],
         ];
     }
 
@@ -63,7 +68,7 @@ class CyclomaticComplexityVisitorTest extends \PHPUnit_Framework_TestCase {
     {
         return [
             [ __DIR__.'/../../examples/cyclomatic1.php', 'A', 6],
-            [ __DIR__.'/../../examples/cyclomatic1.php', 'B', 5],
+            [ __DIR__.'/../../examples/cyclomatic1.php', 'B', 4],
         ];
     }
 

--- a/tests/Metric/Class_/Complexity/CyclomaticComplexityVisitorTest.php
+++ b/tests/Metric/Class_/Complexity/CyclomaticComplexityVisitorTest.php
@@ -3,23 +3,23 @@ namespace Test\Hal\Metric\Class_\Coupling;
 
 use Hal\Metric\Class_\ClassEnumVisitor;
 use Hal\Metric\Class_\Complexity\CyclomaticComplexityVisitor;
-use Hal\Metric\Class_\Complexity\McCabeVisitor;
 use Hal\Metric\Metrics;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\ParserFactory;
 
-class CyclomaticComplexityVisitorTest extends \PHPUnit_Framework_TestCase {
-
-
+class CyclomaticComplexityVisitorTest extends \PHPUnit_Framework_TestCase
+{
     /**
-     * @dataProvider provideExamplesForClasses
+     * @dataProvider provideExamplesForWmc
      */
-    public function testCyclomaticComplexityOfClassesIsWellCalculated($example, $classname, $expectedCcn)
+    public function testWeightedMethodCountOfClassesIsWellCalculated($example, $classname, $expectedWmc)
     {
         $metrics = new Metrics();
 
         $parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        $traverser = new \PhpParser\NodeTraverser();
-        $traverser->addVisitor(new \PhpParser\NodeVisitor\NameResolver());
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver());
         $traverser->addVisitor(new ClassEnumVisitor($metrics));
         $traverser->addVisitor(new CyclomaticComplexityVisitor($metrics));
 
@@ -27,19 +27,19 @@ class CyclomaticComplexityVisitorTest extends \PHPUnit_Framework_TestCase {
         $stmts = $parser->parse($code);
         $traverser->traverse($stmts);
 
-        $this->assertSame($expectedCcn, $metrics->get($classname)->get('ccn'));
+        $this->assertSame($expectedWmc, $metrics->get($classname)->get('ccn'));
     }
 
     /**
-     * @dataProvider provideExamplesForMethods
+     * @dataProvider provideExamplesForMaxCc
      */
-    public function testCyclomaticComplexityOfMethodsIsWellCalculated($example, $classname, $expectedCcnMethodMax)
+    public function testMaximalCyclomaticComplexityOfMethodsIsWellCalculated($example, $classname, $expectedCcnMethodMax)
     {
         $metrics = new Metrics();
 
         $parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        $traverser = new \PhpParser\NodeTraverser();
-        $traverser->addVisitor(new \PhpParser\NodeVisitor\NameResolver());
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver());
         $traverser->addVisitor(new ClassEnumVisitor($metrics));
         $traverser->addVisitor(new CyclomaticComplexityVisitor($metrics));
 
@@ -50,26 +50,25 @@ class CyclomaticComplexityVisitorTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame($expectedCcnMethodMax, $metrics->get($classname)->get('ccnMethodMax'));
     }
 
-    public function provideExamplesForClasses()
+    public static function provideExamplesForWmc()
     {
         return [
-            'A' => [ __DIR__.'/../../examples/cyclomatic1.php', 'A', 8],
-            'B' => [ __DIR__.'/../../examples/cyclomatic1.php', 'B', 4],
-            'Foo\\C' => [ __DIR__.'/../../examples/cyclomatic_anon.php', 'Foo\\C', 1],
-            'SwitchCase' => [ __DIR__.'/../../examples/cyclomatic_full.php', 'SwitchCase', 4],
-            'IfElseif' => [ __DIR__.'/../../examples/cyclomatic_full.php', 'IfElseif', 7],
-            'Loops' => [ __DIR__.'/../../examples/cyclomatic_full.php', 'Loops', 5],
-            'CatchIt' => [ __DIR__.'/../../examples/cyclomatic_full.php', 'CatchIt', 3],
-            'Logical' => [ __DIR__.'/../../examples/cyclomatic_full.php', 'Logical', 11],
+            'A' => [__DIR__ . '/../../examples/cyclomatic1.php', 'A', 10],
+            'B' => [__DIR__ . '/../../examples/cyclomatic1.php', 'B', 4],
+            'Foo\\C' => [__DIR__ . '/../../examples/cyclomatic_anon.php', 'Foo\\C', 1],
+            'SwitchCase' => [__DIR__ . '/../../examples/cyclomatic_full.php', 'SwitchCase', 4],
+            'IfElseif' => [__DIR__ . '/../../examples/cyclomatic_full.php', 'IfElseif', 7],
+            'Loops' => [__DIR__ . '/../../examples/cyclomatic_full.php', 'Loops', 5],
+            'CatchIt' => [__DIR__ . '/../../examples/cyclomatic_full.php', 'CatchIt', 3],
+            'Logical' => [__DIR__ . '/../../examples/cyclomatic_full.php', 'Logical', 11],
         ];
     }
 
-    public function provideExamplesForMethods()
+    public static function provideExamplesForMaxCc()
     {
         return [
-            [ __DIR__.'/../../examples/cyclomatic1.php', 'A', 6],
-            [ __DIR__.'/../../examples/cyclomatic1.php', 'B', 4],
+            [__DIR__ . '/../../examples/cyclomatic1.php', 'A', 6],
+            [__DIR__ . '/../../examples/cyclomatic1.php', 'B', 4],
         ];
     }
-
 }

--- a/tests/Metric/examples/cyclomatic_full.php
+++ b/tests/Metric/examples/cyclomatic_full.php
@@ -1,0 +1,72 @@
+<?php
+class SwitchCase // ccn2: 4
+{
+    function __invoke()
+    {
+        switch ('abc') {
+            case 'abc':
+            case 'def':
+            case 'hij':
+                break;
+            default:
+        }
+    }
+}
+
+class IfElseif // ccn2: 7
+{
+    function __invoke()
+    {
+        if (true) {
+            if (true) {
+            } elseif (true) {
+            } else {
+            }
+        } elseif (true) {
+            if (false) {
+            }
+        }
+
+        if (true) {
+        }
+    }
+}
+
+class Loops // ccn2: 5
+{
+    function __invoke()
+    {
+        while (true) {
+            do {
+            } while (false);
+        }
+        foreach (array() as $each) {
+            for ($i = 0; $i < 0; ++$i) {
+            }
+        }
+    }
+}
+
+class CatchIt // ccn2: 3
+{
+    function __invoke()
+    {
+        try {
+        } catch (Exception $e) {
+        } catch (Throwable $e) {
+        } finally {
+        }
+    }
+}
+
+class Logical // ccn2: 11
+{
+    function __invoke()
+    {
+        $a = (true || false) and (false && true) or (true xor false);
+        $b = $a ? 1 : 2;
+        $c = $b ?: 0;
+        $d = $b ?? $c;
+        $e = $b <=> $d;
+    }
+}


### PR DESCRIPTION
The changes in detail:
 - xor has not been covered yet.
 - The ternary operator and the coalesce operator has been count both
   as 2. Also the default case of a switch statement has been counted.
   But as the else statement is not counted because it represents the
   default path (and can be elimated), the default case should not be
   counted (corresponds to else) and both the ternary and the coalesce
   operator should be counted as 1, because they can be exchanged by
   if-else / if which would be counted as 1.
   The spaceship operator by contrast is now counted as 2, because it
   would need if-elseif-else to replace it.
 - continue does not increase the cyclomatic complexity as its no
   decision. It's the if around the continue which increases the ccn.

I would be very thankfully about any thoughts to this changes.