### PR TITLE
Root path exclude conflict fix

### DIFF
--- a/src/Hal/Component/File/Finder.php
+++ b/src/Hal/Component/File/Finder.php
@@ -48,8 +48,8 @@ class Finder
     private $flags;
 
     /**
-     * @param string $extensions regex of file extensions to include
-     * @param string $excludedDirs regex of directories to exclude
+     * @param string[] $extensions   regex of file extensions to include
+     * @param string[] $excludedDirs regex of directories to exclude
      * @param integer $flags
      */
     public function __construct(array $extensions = ['php'], array $excludedDirs = [], $flags = null)

--- a/src/Hal/Component/File/Finder.php
+++ b/src/Hal/Component/File/Finder.php
@@ -76,7 +76,8 @@ class Finder
                 $iterator = new RecursiveIteratorIterator($directory);
 
                 $filterRegex = sprintf(
-                    '`^%s%s$`',
+                    '`^%s%s%s$`',
+                    $path,
                     !empty($this->excludedDirs) ? '((?!' . implode('|', array_map('preg_quote', $this->excludedDirs)) . ').)+' : '.+',
                     '\.(' . implode('|', $this->extensions) . ')'
                 );


### PR DESCRIPTION
Hi,

Currently, trying to run phpmetrics on paths containing any default excluded names (vendor, test, spec) fails because no files are found.

Here are some examples:
```
/home/tester/project-root/main.php	path contains "test"
./projects/respect/folder/		path contains "spec"
```