### PR TITLE
fix for repeating bloc-ids

### DIFF
--- a/src/Hal/Report/Html/template/violations.php
+++ b/src/Hal/Report/Html/template/violations.php
@@ -57,7 +57,7 @@ $map = [
                     <tbody>
                     <?php foreach ($classes as $class) {
                         if (sizeof($class['violations']) > 0) {
-                            $currentId = 'bloc-' . uniqid();
+                            $currentId = 'bloc-' . uniqid('', true);
                             ?>
 
                             <tr>


### PR DESCRIPTION
Same bloc-id is generated across multiple classes in the violations report.