### PR TITLE
Adjust cc violation limits

### DIFF
--- a/src/Hal/Metric/Class_/Complexity/CyclomaticComplexityVisitor.php
+++ b/src/Hal/Metric/Class_/Complexity/CyclomaticComplexityVisitor.php
@@ -10,16 +10,16 @@ use PhpParser\NodeVisitorAbstract;
 /**
  * Calculate cyclomatic complexity number and weighted method count.
  *
- * The cyclomatic complexity (CC) is a measure of control structure complexity of a function or procedure.
+ * The cyclomatic complexity (CCN) is a measure of control structure complexity of a function or procedure.
  * We can calculate ccn in two ways (we choose the second):
  *
- *  1.  Cyclomatic complexity (CC) = E - N + 2P
+ *  1.  Cyclomatic complexity (CCN) = E - N + 2P
  *      Where:
  *      P = number of disconnected parts of the flow graph (e.g. a calling program and a subroutine)
  *      E = number of edges (transfers of control)
  *      N = number of nodes (sequential group of statements containing only one transfer of control)
  *
- *  2. CC = Number of each decision point
+ *  2. CCN = Number of each decision point
  *
  * The weighted method count (WMC) is count of methods parameterized by a algorithm to compute the weight of a method.
  * Given a weight metric w and methods m it can be computed as
@@ -32,8 +32,8 @@ use PhpParser\NodeVisitorAbstract;
  *  - Lines of Code
  *  - 1 (unweighted WMC)
  *
- * This visitor provides two metrics, the maximal CC of all methods from one class (currently stored as ccnMethodMax)
- * and the WMC using the CC as weight metric (currently stored as ccn).
+ * This visitor provides two metrics, the maximal CCN of all methods from one class (currently stored as ccnMethodMax)
+ * and the WMC using the CCN as weight metric (currently stored as ccn).
  *
  * @see https://en.wikipedia.org/wiki/Cyclomatic_complexity
  * @see http://www.literateprogramming.com/mccabe.pdf

--- a/src/Hal/Violation/Class_/TooComplexClassCode.php
+++ b/src/Hal/Violation/Class_/TooComplexClassCode.php
@@ -1,51 +1,44 @@
 <?php
 namespace Hal\Violation\Class_;
 
-
 use Hal\Metric\ClassMetric;
 use Hal\Metric\Metric;
 use Hal\Violation\Violation;
 
+/**
+ * 50 as a threshold seems to be widely accepted in open source metric tools.
+ *
+ * @see http://staff.unak.is/andy/StaticAnalysis0809/metrics/wmc.html
+ * @see https://github.com/phpmd/phpmd/blob/f1c145e538d7cf8c2d1a45fd8fb723eca64005f4/src/main/resources/rulesets/codesize.xml#L390
+ */
 class TooComplexClassCode implements Violation
 {
+    /** @var Metric|null */
+    private $metric;
 
-    /**
-     * @inheritdoc
-     */
     public function getName()
     {
         return 'Too complex class code';
     }
 
-    /**
-     * @inheritdoc
-     */
     public function apply(Metric $metric)
     {
-        if (!$metric instanceof ClassMetric) {
+        if (! $metric instanceof ClassMetric) {
             return;
         }
 
         $this->metric = $metric;
 
-        if ($metric->get('ccn') >= 25) {
+        if ($metric->get('ccn') > 50) {
             $metric->get('violations')->add($this);
-            return;
         }
-
     }
 
-    /**
-     * @inheritdoc
-     */
     public function getLevel()
     {
         return Violation::ERROR;
     }
 
-    /**
-     * @inheritdoc
-     */
     public function getDescription()
     {
         return <<<EOT
@@ -56,6 +49,5 @@ This class looks really complex.
 
 Maybe you should delegate some code to other objects.
 EOT;
-
     }
 }

--- a/src/Hal/Violation/Class_/TooComplexMethodCode.php
+++ b/src/Hal/Violation/Class_/TooComplexMethodCode.php
@@ -1,51 +1,48 @@
 <?php
 namespace Hal\Violation\Class_;
 
-
 use Hal\Metric\ClassMetric;
 use Hal\Metric\Metric;
 use Hal\Violation\Violation;
 
+/**
+ * According to McCabe,
+ *
+ *  The particular upper bound that has been used for cyclomatic complexity is 10
+ *  which seems like a reasonable, but not magical, upper limit.
+ *
+ * @see http://www.literateprogramming.com/mccabe.pdf
+ */
 class TooComplexMethodCode implements Violation
 {
+    /** @var Metric|null */
+    private $metric;
 
-    /**
-     * @inheritdoc
-     */
     public function getName()
     {
         return 'Too complex method code';
     }
 
-    /**
-     * @inheritdoc
-     */
     public function apply(Metric $metric)
     {
-        if (!$metric instanceof ClassMetric) {
+        if (! $metric instanceof ClassMetric) {
             return;
         }
 
         $this->metric = $metric;
 
-        if ($metric->get('ccnMethodMax') >= 8) {
+        if ($metric->get('ccnMethodMax') > 10) {
             $metric->get('violations')->add($this);
             return;
         }
 
     }
 
-    /**
-     * @inheritdoc
-     */
     public function getLevel()
     {
         return Violation::ERROR;
     }
 
-    /**
-     * @inheritdoc
-     */
     public function getDescription()
     {
         return <<<EOT
@@ -55,6 +52,5 @@ This class looks really complex.
 
 Maybe you should delegate some code to other objects or split complex method.
 EOT;
-
     }
 }


### PR DESCRIPTION
Changing the CCN and WMC calculation results in higher CCN and especially WMC values.

Therefore the threshold for violations should to be adjusted too.
For the CCN 10 as a threshold is suggested by McCabe itself.
For the WMC no source could be found, but in other open source metric tools 50 has been found as threshold.

Applying this thresholds on symfony leeds to the following violations:

|                            | CCN violations | WMC violations |
| -------------------------- | -------------- | -------------- |
| Before changing ccn        |       104      |       237      |
| After changing ccn         |       297      |       458      |
| After adjusting thresholds |       115      |       293      |

Altogether when applying the new CCN calculation with the new thresholds, which are based on resources, the number of violations does not change significantly.