### PR TITLE
Retain the old ccn and add wmc as new metric

### DIFF
--- a/src/Hal/Metric/Class_/Complexity/CyclomaticComplexityVisitor.php
+++ b/src/Hal/Metric/Class_/Complexity/CyclomaticComplexityVisitor.php
@@ -57,7 +57,8 @@ class CyclomaticComplexityVisitor extends NodeVisitorAbstract
         ) {
             $class = $this->metrics->get(MetricClassNameGenerator::getName($node));
 
-            $ccn = 0;
+            $ccn = 1;
+            $wmc = 0;
             $ccnByMethod = [0]; // default maxMethodCcn if no methods are available
 
             foreach ($node->stmts as $stmt) {
@@ -106,11 +107,13 @@ class CyclomaticComplexityVisitor extends NodeVisitorAbstract
 
                     $methodCcn = $cb($stmt) + 1; // each method by default is CCN 1 even if it's empty
 
-                    $ccn += $methodCcn;
+                    $wmc += $methodCcn;
+                    $ccn += $methodCcn - 1;
                     $ccnByMethod[] = $methodCcn;
                 }
             }
 
+            $class->set('wmc', $wmc);
             $class->set('ccn', $ccn);
             $class->set('ccnMethodMax', max($ccnByMethod));
         }

--- a/src/Hal/Metric/Consolidated.php
+++ b/src/Hal/Metric/Consolidated.php
@@ -74,6 +74,7 @@ class Consolidated
             'nbMethods' => 0,
         ];
         $avg = (object)[
+            'wmc' => [],
             'ccn' => [],
             'bugs' => [],
             'kanDefect' => [],

--- a/src/Hal/Report/Cli/Reporter.php
+++ b/src/Hal/Report/Cli/Reporter.php
@@ -87,6 +87,7 @@ Package
 
 Complexity
     Average Cyclomatic complexity by class      {$avg->ccn}
+    Average Weighted method count by class      {$avg->wmc}
     Average Relative system complexity          {$avg->relativeSystemComplexity}
     Average Difficulty                          {$avg->difficulty}
     

--- a/src/Hal/Report/Html/template/complexity.php
+++ b/src/Hal/Report/Html/template/complexity.php
@@ -4,6 +4,15 @@ require __DIR__ . '/_header.php'; ?>
     <div class="row">
         <div class="column">
             <div class="bloc bloc-number">
+                <div class="label">Average weighted method count by class <small>(CC)</small></div>
+                <div class="number">
+                    <?php echo $avg->wmc; ?>
+                </div>
+                <?php echo $this->getTrend('avg', 'wmc', true); ?>
+            </div>
+        </div>
+        <div class="column">
+            <div class="bloc bloc-number">
                 <div class="label">Average cyclomatic complexity by class</div>
                 <div class="number">
                     <?php echo $avg->ccn; ?>
@@ -22,26 +31,23 @@ require __DIR__ . '/_header.php'; ?>
         </div>
         <div class="column">
             <div class="bloc bloc-number">
-                <div class="label">Average bugs by class
-                    <small>(Halstead)</small> <?php echo $this->getTrend('avg', 'bugs', true); ?>
-                </div>
+                <div class="label">Average bugs by class<small>(Halstead)</small></div>
                 <div class="number">
                     <?php echo $avg->bugs; ?>
                 </div>
+                <?php echo $this->getTrend('avg', 'bugs', true); ?>
             </div>
         </div>
         <div class="column">
             <div class="bloc bloc-number">
-                <div class="label">average defects by class
-                    <small>(Kan)</small> <?php echo $this->getTrend('avg', 'kanDefect', true); ?>
-                </div>
+                <div class="label">average defects by class <small>(Kan)</small></div>
                 <div class="number">
                     <?php echo $avg->kanDefect; ?>
                 </div>
+                <?php echo $this->getTrend('avg', 'kanDefect', true); ?>
             </div>
         </div>
     </div>
-
 
     <div class="row">
         <div class="column">
@@ -50,6 +56,7 @@ require __DIR__ . '/_header.php'; ?>
                     <thead>
                     <tr>
                         <th>Class</th>
+                        <th class="js-sort-number">WMC</th>
                         <th class="js-sort-number">Class cycl.</th>
                         <th class="js-sort-number">Max method cycl.</th>
                         <?php if ($config->has('junit')) { ?>
@@ -65,6 +72,7 @@ require __DIR__ . '/_header.php'; ?>
                     foreach ($classes as $class) { ?>
                         <tr>
                             <td><?php echo $class['name']; ?></td>
+                            <td><?php echo isset($class['wmc']) ? $class['wmc'] : ''; ?></td>
                             <td><?php echo isset($class['ccn']) ? $class['ccn'] : ''; ?></td>
                             <td><?php echo isset($class['ccnMethodMax']) ? $class['ccnMethodMax'] : ''; ?></td>
                             <?php if ($config->has('junit')) { ?>

--- a/src/Hal/Report/Html/template/index.php
+++ b/src/Hal/Report/Html/template/index.php
@@ -11,8 +11,8 @@
         <div class="column">
             <div class="bloc bloc-number">
                 <div class="label"><a href="loc.html">Lines of code</a></div>
-                <?php echo $this->getTrend('sum', 'loc'); ?>
                 <div class="number"><?php echo $sum->loc; ?></div>
+                <?php echo $this->getTrend('sum', 'loc'); ?>
             </div>
         </div>
         <div class="column">

--- a/src/Hal/Violation/Class_/TooComplexClassCode.php
+++ b/src/Hal/Violation/Class_/TooComplexClassCode.php
@@ -29,7 +29,7 @@ class TooComplexClassCode implements Violation
 
         $this->metric = $metric;
 
-        if ($metric->get('ccn') > 50) {
+        if ($metric->get('wmc') > 50) {
             $metric->get('violations')->add($this);
         }
     }

--- a/tests/Metric/Class_/Complexity/CyclomaticComplexityVisitorTest.php
+++ b/tests/Metric/Class_/Complexity/CyclomaticComplexityVisitorTest.php
@@ -11,6 +11,26 @@ use PhpParser\ParserFactory;
 class CyclomaticComplexityVisitorTest extends \PHPUnit_Framework_TestCase
 {
     /**
+     * @dataProvider provideExamplesForCcn
+     */
+    public function testCcnOfClassesIsWellCalculated($example, $classname, $expectedCcn)
+    {
+        $metrics = new Metrics();
+
+        $parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver());
+        $traverser->addVisitor(new ClassEnumVisitor($metrics));
+        $traverser->addVisitor(new CyclomaticComplexityVisitor($metrics));
+
+        $code = file_get_contents($example);
+        $stmts = $parser->parse($code);
+        $traverser->traverse($stmts);
+
+        $this->assertSame($expectedCcn, $metrics->get($classname)->get('ccn'));
+    }
+
+    /**
      * @dataProvider provideExamplesForWmc
      */
     public function testWeightedMethodCountOfClassesIsWellCalculated($example, $classname, $expectedWmc)
@@ -27,7 +47,7 @@ class CyclomaticComplexityVisitorTest extends \PHPUnit_Framework_TestCase
         $stmts = $parser->parse($code);
         $traverser->traverse($stmts);
 
-        $this->assertSame($expectedWmc, $metrics->get($classname)->get('ccn'));
+        $this->assertSame($expectedWmc, $metrics->get($classname)->get('wmc'));
     }
 
     /**
@@ -54,6 +74,20 @@ class CyclomaticComplexityVisitorTest extends \PHPUnit_Framework_TestCase
     {
         return [
             'A' => [__DIR__ . '/../../examples/cyclomatic1.php', 'A', 10],
+            'B' => [__DIR__ . '/../../examples/cyclomatic1.php', 'B', 4],
+            'Foo\\C' => [__DIR__ . '/../../examples/cyclomatic_anon.php', 'Foo\\C', 1],
+            'SwitchCase' => [__DIR__ . '/../../examples/cyclomatic_full.php', 'SwitchCase', 4],
+            'IfElseif' => [__DIR__ . '/../../examples/cyclomatic_full.php', 'IfElseif', 7],
+            'Loops' => [__DIR__ . '/../../examples/cyclomatic_full.php', 'Loops', 5],
+            'CatchIt' => [__DIR__ . '/../../examples/cyclomatic_full.php', 'CatchIt', 3],
+            'Logical' => [__DIR__ . '/../../examples/cyclomatic_full.php', 'Logical', 11],
+        ];
+    }
+
+    public static function provideExamplesForCcn()
+    {
+        return [
+            'A' => [__DIR__ . '/../../examples/cyclomatic1.php', 'A', 8],
             'B' => [__DIR__ . '/../../examples/cyclomatic1.php', 'B', 4],
             'Foo\\C' => [__DIR__ . '/../../examples/cyclomatic_anon.php', 'Foo\\C', 1],
             'SwitchCase' => [__DIR__ . '/../../examples/cyclomatic_full.php', 'SwitchCase', 4],


### PR DESCRIPTION
CCN by Class is deprecated and will be removed in v3.
WMC should be used instead.
To be BC compatible the CCN by Class will be retained until v3.

Fixes #359