### PR TITLE
file_exists > is_file

### DIFF
--- a/bin/phpmetrics
+++ b/bin/phpmetrics
@@ -2,7 +2,7 @@
 <?php
 function includeIfExists($file)
 {
-    if (file_exists($file)) {
+    if (is_file($file)) {
         return include $file;
     }
 }


### PR DESCRIPTION
file_exists doesn't makes difference between dir and file.
is_file is a better practice.