### PR TITLE
Skip `self` and `parent` from external dependencies

### DIFF
--- a/tests/Metric/examples/externals1.php
+++ b/tests/Metric/examples/externals1.php
@@ -14,13 +14,19 @@ namespace {
         }
     }
     class C {
-
+        public static function create()
+        {
+            return new self();
+        }
     }
     class D {
 
     }
     class E extends D implements F, G {
-
+        public function __construct()
+        {
+            parent::__construct();
+        }
     }
     interface F extends G, H {
 


### PR DESCRIPTION
`self` and  `parent` shouldn't appear in class dependency graph.

## Code example:

````php
namespace App;

class ParentClass
{
    public function __construct(int $a)
    {
    }
}

class SubClass extends ParentClass
{
    public function __construct(int $a, int $b)
    {
        parent::__construct($a);
    }

    public static function create(): self
    {
        return new self(1, 1);
    }
}
````

Before (wrong):
![image](https://user-images.githubusercontent.com/191887/53891003-ace47180-4029-11e9-850e-f3d91f935e56.png)

After:
![image](https://user-images.githubusercontent.com/191887/53890977-9e965580-4029-11e9-82cc-9a2d75af66ca.png)


