### PR TITLE
Include codesniffer. Remove alias function and short array syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ before_script:
 
 script:
   - make test
+  - make phpcs
   - docker run --rm test_phpmetrics
 
 before_deploy:

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ test:
 	./vendor/bin/phpunit -c phpunit.xml.dist
 
 # Codesniffer fix
+phpcs:
+	./vendor/bin/phpcs src/ tests/ --extensions=php -n
+
+# Codesniffer fix
 phpcbf:
 	./vendor/bin/phpcbf src/ tests/ --extensions=php -n
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ include artifacts/Makefile
 test:
 	./vendor/bin/phpunit -c phpunit.xml.dist
 
-# Codesniffer fix
+# Codesniffer check
 phpcs:
 	./vendor/bin/phpcs src/ tests/ --extensions=php -n
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ include artifacts/Makefile
 test:
 	./vendor/bin/phpunit -c phpunit.xml.dist
 
+# Codesniffer fix
+phpcbf:
+	./vendor/bin/phpcbf src/ tests/ --extensions=php -n
+
 # Publish new release. Usage:
 #   make tag VERSION=(major|minor|patch)
 # You need to install https://github.com/flazz/semver/ before

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=4.8.27,<=5.7.13",
-        "sebastian/comparator": ">=1.2.3"
+        "sebastian/comparator": ">=1.2.3",
+        "squizlabs/php_codesniffer": "^3.5"
     },
     "bin": [
         "bin/phpmetrics"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<ruleset name="PhpMetrics">
+<ruleset name="PhpMetrics"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/squizlabs/php_codesniffer/phpcs.xsd"
+>
     <description>The coding standard of PhpMetrics package</description>
 
     <arg value="p"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<ruleset name="PhpMetrics">
+    <description>The coding standard of PhpMetrics package</description>
+
+    <arg value="p"/>
+
+    <config name="ignore_warnings_on_exit" value="1"/>
+    <config name="ignore_errors_on_exit" value="1"/>
+
+    <arg name="colors"/>
+    <arg value="s"/>
+
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+
+    <rule ref="Generic.PHP.ForbiddenFunctions">
+        <properties>
+            <property name="forbiddenFunctions" type="array">
+                <element key="chop" value="rtrim"/>
+                <element key="close" value="closedir"/>
+                <element key="compact" value="null"/>
+                <element key="delete" value="unset"/>
+                <element key="doubleval" value="floatval"/>
+                <element key="extract" value="null"/>
+                <element key="fputs" value="fwrite"/>
+                <element key="ini_alter" value="ini_set"/>
+                <element key="is_double" value="is_float"/>
+                <element key="is_integer" value="is_int"/>
+                <element key="is_long" value="is_int"/>
+                <element key="is_null" value="null"/>
+                <element key="is_real" value="is_float"/>
+                <element key="is_writeable" value="is_writable"/>
+                <element key="join" value="implode"/>
+                <element key="key_exists" value="array_key_exists"/>
+                <element key="pos" value="current"/>
+                <element key="settype" value="null"/>
+                <element key="show_source" value="highlight_file"/>
+                <element key="sizeof" value="count"/>
+                <element key="strchr" value="strstr"/>
+            </property>
+        </properties>
+    </rule>
+</ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -8,7 +8,6 @@
     <arg value="p"/>
 
     <config name="ignore_warnings_on_exit" value="1"/>
-    <config name="ignore_errors_on_exit" value="1"/>
 
     <arg name="colors"/>
     <arg value="s"/>

--- a/src/Hal/Application/Analyze.php
+++ b/src/Hal/Application/Analyze.php
@@ -96,7 +96,7 @@ class Analyze
         $traverser->addVisitor(new PackageCollectingVisitor($metrics));
 
         // create a new progress bar (50 units)
-        $progress = new ProgressBar($this->output, sizeof($files));
+        $progress = new ProgressBar($this->output, count($files));
         $progress->start();
 
         foreach ($files as $file) {

--- a/src/Hal/Application/Config/File/ConfigFileReaderJson.php
+++ b/src/Hal/Application/Config/File/ConfigFileReaderJson.php
@@ -63,7 +63,7 @@ class ConfigFileReaderJson implements ConfigFileReaderInterface
             foreach (range(0, $iterator->getDepth()) as $depth) {
                 $keys[] = $iterator->getSubIterator($depth)->key();
             }
-            $result[join('-', $keys)] = $leafValue;
+            $result[implode('-', $keys)] = $leafValue;
         }
 
         return $result;

--- a/src/Hal/Application/Config/Parser.php
+++ b/src/Hal/Application/Config/Parser.php
@@ -9,7 +9,7 @@ class Parser
     {
         $config = new Config;
 
-        if (sizeof($argv) === 0) {
+        if (count($argv) === 0) {
             return $config;
         }
 

--- a/src/Hal/Component/Ast/NodeTraverser.php
+++ b/src/Hal/Component/Ast/NodeTraverser.php
@@ -48,7 +48,7 @@ class Traverser
      * @return array
      */
     public function traverseArray(array $nodes, array $visitors) {
-        $doNodes = array();
+        $doNodes = [];
 
         foreach ($nodes as $i => &$node) {
             if (is_array($node)) {
@@ -73,10 +73,10 @@ class Traverser
                     $return = $visitor->leaveNode($node);
 
                     if (Mother::REMOVE_NODE === $return) {
-                        $doNodes[] = array($i, array());
+                        $doNodes[] = [$i, []];
                         break;
                     } elseif (is_array($return)) {
-                        $doNodes[] = array($i, $return);
+                        $doNodes[] = [$i, $return];
                         break;
                     } elseif (null !== $return) {
                         $node = $return;

--- a/src/Hal/Component/File/Finder.php
+++ b/src/Hal/Component/File/Finder.php
@@ -68,7 +68,7 @@ class Finder
      */
     public function fetch(array $paths)
     {
-        $files = array();
+        $files = [];
         foreach ($paths as $path) {
             if (is_dir($path)) {
                 $path = rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;

--- a/src/Hal/Component/Tree/Graph.php
+++ b/src/Hal/Component/Tree/Graph.php
@@ -14,12 +14,12 @@ class Graph implements \Countable
     /**
      * @var Node[]
      */
-    private $datas = array();
+    private $datas = [];
 
     /**
      * @var Edge[]
      */
-    private $edges = array();
+    private $edges = [];
 
     /**
      * @param Node $node
@@ -102,7 +102,7 @@ class Graph implements \Countable
      */
     public function count()
     {
-        return sizeof($this->datas);
+        return count($this->datas);
     }
 
     /**

--- a/src/Hal/Component/Tree/HashMap.php
+++ b/src/Hal/Component/Tree/HashMap.php
@@ -14,7 +14,7 @@ class HashMap implements \Countable, \IteratorAggregate
     /**
      * @var array
      */
-    private $nodes = array();
+    private $nodes = [];
 
     /**
      * @param Node $node
@@ -49,7 +49,7 @@ class HashMap implements \Countable, \IteratorAggregate
      */
     public function count()
     {
-        return sizeof($this->nodes);
+        return count($this->nodes);
     }
 
     /**

--- a/src/Hal/Component/Tree/Node.php
+++ b/src/Hal/Component/Tree/Node.php
@@ -25,7 +25,7 @@ class Node
     /**
      * @var Edge[]
      */
-    private $edges = array();
+    private $edges = [];
 
     /**
      * @var bool

--- a/src/Hal/Component/Tree/Operator/SizeOfTree.php
+++ b/src/Hal/Component/Tree/Operator/SizeOfTree.php
@@ -43,7 +43,7 @@ class SizeOfTree
 
         $edges = $node->getEdges();
 
-        if (0 === sizeof($edges)) {
+        if (0 === count($edges)) {
             return 0;
         }
 
@@ -75,7 +75,7 @@ class SizeOfTree
 
         $edges = $node->getEdges();
 
-        if (0 === sizeof($edges)) {
+        if (0 === count($edges)) {
             return 0;
         }
 
@@ -119,7 +119,7 @@ class SizeOfTree
         foreach ($this->graph->getRootNodes() as $node) {
             array_push($ns, $this->getLongestBranch($node));
         }
-        return round(array_sum($ns) / max(1, sizeof($ns)), 2);
+        return round(array_sum($ns) / max(1, count($ns)), 2);
     }
 
     /**

--- a/src/Hal/Metric/Class_/ClassEnumVisitor.php
+++ b/src/Hal/Metric/Class_/ClassEnumVisitor.php
@@ -84,8 +84,8 @@ class ClassEnumVisitor extends NodeVisitorAbstract
             }
 
             $class->set('methods', $methods);
-            $class->set('nbMethodsIncludingGettersSetters', sizeof($methods) );
-            $class->set('nbMethods', sizeof($methods) - ($nbGetters + $nbSetters));
+            $class->set('nbMethodsIncludingGettersSetters', count($methods) );
+            $class->set('nbMethods', count($methods) - ($nbGetters + $nbSetters));
             $class->set('nbMethodsPrivate', $methodsPrivate);
             $class->set('nbMethodsPublic', $methodsPublic);
             $class->set('nbMethodsGetter', $nbGetters);

--- a/src/Hal/Metric/Class_/Structural/SystemComplexityVisitor.php
+++ b/src/Hal/Metric/Class_/Structural/SystemComplexityVisitor.php
@@ -44,7 +44,7 @@ class SystemComplexityVisitor extends NodeVisitorAbstract
 
             $class = $this->metrics->get(MetricClassNameGenerator::getName($node));
 
-            $sy = $dc = $sc = array();
+            $sy = $dc = $sc = [];
 
             foreach ($node->stmts as $stmt) {
                 if ($stmt instanceof Stmt\ClassMethod) {
@@ -64,8 +64,8 @@ class SystemComplexityVisitor extends NodeVisitorAbstract
                         }
                     });
 
-                    $fanout = sizeof(array_unique($fanout));
-                    $v = sizeof($stmt->params) + $output;
+                    $fanout = count(array_unique($fanout));
+                    $v = count($stmt->params) + $output;
                     $ldc = $v / ($fanout + 1);
                     $lsc = pow($fanout, 2);
                     $sy[] = $ldc + $lsc;
@@ -76,9 +76,9 @@ class SystemComplexityVisitor extends NodeVisitorAbstract
 
             // average for class
             $class
-                ->set('relativeStructuralComplexity', empty($sc) ? 0 : round(array_sum($sc) / sizeof($sc), 2))
-                ->set('relativeDataComplexity', empty($dc) ? 0 : round(array_sum($dc) / sizeof($dc), 2))
-                ->set('relativeSystemComplexity', empty($sy) ? 0 : round(array_sum($sy) / sizeof($sy), 2))
+                ->set('relativeStructuralComplexity', empty($sc) ? 0 : round(array_sum($sc) / count($sc), 2))
+                ->set('relativeDataComplexity', empty($dc) ? 0 : round(array_sum($dc) / count($dc), 2))
+                ->set('relativeSystemComplexity', empty($sy) ? 0 : round(array_sum($sy) / count($sy), 2))
                 ->set('totalStructuralComplexity', round(array_sum($sc), 2))
                 ->set('totalDataComplexity', round(array_sum($dc), 2))
                 ->set('totalSystemComplexity', round(array_sum($dc) + array_sum($sc), 2));

--- a/src/Hal/Metric/Class_/Text/HalsteadVisitor.php
+++ b/src/Hal/Metric/Class_/Text/HalsteadVisitor.php
@@ -105,10 +105,10 @@ class HalsteadVisitor extends NodeVisitorAbstract
             $uniqueOperators = array_map('unserialize', array_unique(array_map('serialize', $operators)));
             $uniqueOperands = array_map('unserialize', array_unique(array_map('serialize', $operands)));
 
-            $n1 = sizeof($uniqueOperators, COUNT_NORMAL);
-            $n2 = sizeof($uniqueOperands, COUNT_NORMAL);
-            $N1 = sizeof($operators, COUNT_NORMAL);
-            $N2 = sizeof($operands, COUNT_NORMAL);
+            $n1 = count($uniqueOperators, COUNT_NORMAL);
+            $n2 = count($uniqueOperands, COUNT_NORMAL);
+            $N1 = count($operators, COUNT_NORMAL);
+            $N2 = count($operands, COUNT_NORMAL);
 
             if (($n2 == 0) || ($N2 == 0)) {
                 // files without operators

--- a/src/Hal/Metric/Class_/Text/LengthVisitor.php
+++ b/src/Hal/Metric/Class_/Text/LengthVisitor.php
@@ -46,16 +46,16 @@ class LengthVisitor extends NodeVisitorAbstract
 
 
             $prettyPrinter = new PrettyPrinter\Standard();
-            $code = $prettyPrinter->prettyPrintFile(array($node));
+            $code = $prettyPrinter->prettyPrintFile([$node]);
 
             // count all lines
-            $loc = sizeof(preg_split('/\r\n|\r|\n/', $code)) - 1;
+            $loc = count(preg_split('/\r\n|\r|\n/', $code)) - 1;
 
             // count and remove multi lines comments
             $cloc = 0;
             if (preg_match_all('!/\*.*?\*/!s', $code, $matches)) {
                 foreach ($matches[0] as $match) {
-                    $cloc += max(1, sizeof(preg_split('/\r\n|\r|\n/', $match)));
+                    $cloc += max(1, count(preg_split('/\r\n|\r|\n/', $match)));
                 }
             }
             $code = preg_replace('!/\*.*?\*/!s', '', $code);
@@ -70,7 +70,7 @@ class LengthVisitor extends NodeVisitorAbstract
 
             // count and remove empty lines
             $code = trim(preg_replace('!(^\s*[\r\n])!sm', '', $code));
-            $lloc = sizeof(preg_split('/\r\n|\r|\n/', $code));
+            $lloc = count(preg_split('/\r\n|\r|\n/', $code));
 
             // save result
             $classOrFunction

--- a/src/Hal/Metric/Consolidated.php
+++ b/src/Hal/Metric/Consolidated.php
@@ -107,8 +107,8 @@ class Consolidated
         $sum->nbPackages = count($packages);
 
         foreach ($avg as &$a) {
-            if (sizeof($a) > 0) {
-                $a = round(array_sum($a) / sizeof($a), 2);
+            if (count($a) > 0) {
+                $a = round(array_sum($a) / count($a), 2);
             } else {
                 $a = 0;
             }

--- a/src/Hal/Metric/Helper/RoleOfMethodDetector.php
+++ b/src/Hal/Metric/Helper/RoleOfMethodDetector.php
@@ -101,7 +101,7 @@ class RoleOfMethodDetector
 
             // avoid fluent interface
             if ($node instanceof Return_ && $node->expr instanceof Variable && $node->expr->name === 'this') {
-                unset($fingerprintOfMethod[sizeof($fingerprintOfMethod) - 1]);
+                unset($fingerprintOfMethod[count($fingerprintOfMethod) - 1]);
                 return;
             }
 

--- a/src/Hal/Metric/System/Changes/GitChanges.php
+++ b/src/Hal/Metric/System/Changes/GitChanges.php
@@ -104,7 +104,7 @@ class GitChanges
                 list(, $timestamp, $author) = $matches;
                 $date = (new \DateTime())->setTimestamp($timestamp)->format($dateFormat);
 
-                if (is_null($firstCommitDate)) {
+                if ($firstCommitDate === null) {
                     $firstCommitDate = $timestamp;
                 }
 

--- a/src/Hal/Metric/System/Changes/GitChanges.php
+++ b/src/Hal/Metric/System/Changes/GitChanges.php
@@ -46,7 +46,7 @@ class GitChanges
             $bin = 'git';
         }
 
-        if (sizeof($this->files) == 0) {
+        if (count($this->files) == 0) {
             return;
         }
 

--- a/src/Hal/Metric/System/Coupling/PageRank.php
+++ b/src/Hal/Metric/System/Coupling/PageRank.php
@@ -44,8 +44,8 @@ class PageRank
      */
     private function calculatePageRank($linkGraph, $dampingFactor = 0.15)
     {
-        $pageRank = array();
-        $tempRank = array();
+        $pageRank = [];
+        $tempRank = [];
         $nodeCount = count($linkGraph);
 
         // initialise the PR as 1/n

--- a/src/Hal/Metric/System/Packages/Composer/Composer.php
+++ b/src/Hal/Metric/System/Packages/Composer/Composer.php
@@ -45,7 +45,7 @@ class Composer
 
             $package = $packagist->get($requirement);
 
-            $packages[$requirement] = (object)array(
+            $packages[$requirement] = (object)[
                 'name' => $requirement,
                 'required' => $version,
                 'installed' => isset($rawInstalled[$requirement]) ? $rawInstalled[$requirement] : null,
@@ -53,7 +53,7 @@ class Composer
                 'license' => $package->license,
                 'homepage' => $package->homepage,
                 'zip' => $package->zip,
-            );
+            ];
         }
 
         $projectMetric->set('packages', $packages);

--- a/src/Hal/Metric/System/UnitTesting/UnitTesting.php
+++ b/src/Hal/Metric/System/UnitTesting/UnitTesting.php
@@ -137,7 +137,7 @@ class UnitTesting
 
             // global stats for each test
             $infoAboutTests[$suite->name] = (object)[
-                'nbExternals' => sizeof(array_unique($externals)),
+                'nbExternals' => count(array_unique($externals)),
                 'externals' => array_unique($externals),
                 'filename' => $suite->file,
                 'classname' => $suite->name,
@@ -177,7 +177,7 @@ class UnitTesting
 
         $projectMetric->set('assertions', $assertions);
         $projectMetric->set('tests', $infoAboutTests);
-        $projectMetric->set('nbSuites', sizeof($testsuites));
+        $projectMetric->set('nbSuites', count($testsuites));
         $projectMetric->set('nbCoveredClasses', $nb);
         $projectMetric->set('percentCoveredClasses', round($nb / max($sum, 1) * 100, 2));
         $projectMetric->set('nbUncoveredClasses', $sum - $nb);

--- a/src/Hal/Report/Cli/Reporter.php
+++ b/src/Hal/Report/Cli/Reporter.php
@@ -116,7 +116,7 @@ EOT;
             foreach ($commits as $file => $nb) {
                 $out .= sprintf("\n    %d    %s", $nb, $file);
             }
-            if (0 === sizeof($commits)) {
+            if (0 === count($commits)) {
                 $out .= "\n    NA";
             }
             $out .= "\n";

--- a/src/Hal/Report/Html/Reporter.php
+++ b/src/Hal/Report/Html/Reporter.php
@@ -49,7 +49,7 @@ class Reporter
             'sum' => $consolidated->getSum()
         ];
         $files = glob($logDir . '/js/history-*.json');
-        $next = sizeof($files) + 1;
+        $next = count($files) + 1;
         $history = [];
         natsort($files);
         foreach ($files as $filename) {

--- a/src/Hal/Report/Html/template/all.php
+++ b/src/Hal/Report/Html/template/all.php
@@ -29,7 +29,7 @@ foreach ($classes as $c) {
                     <?php foreach ($classesC as $class) { ?>
                         <tr>
                             <?php foreach ($class as $k => $v) { ?>
-                                <td class="js-sort-number"><?php echo is_array($v) ? sizeof($v) : $v; ?></td>
+                                <td class="js-sort-number"><?php echo is_array($v) ? count($v) : $v; ?></td>
                             <?php } ?>
                         </tr>
                     <?php } ?>

--- a/src/Hal/Report/Html/template/index.php
+++ b/src/Hal/Report/Html/template/index.php
@@ -168,7 +168,7 @@
         <div class="column">
             <div class="bloc bloc-number">
                 <div class="label">Licences of Composer dependencies</div>
-                <?php if(0 === sizeof($packages)) { ?>
+                <?php if(0 === count($packages)) { ?>
                     <div>No composer.json file found</div>
                 <?php } ?>
                 <div id="svg-licenses"></div>

--- a/src/Hal/Report/Html/template/loc.php
+++ b/src/Hal/Report/Html/template/loc.php
@@ -19,7 +19,7 @@ foreach ($classes as $class) {
 
 // 2. percentile map
 $json = [];
-if(sizeof($array) > 1) {
+if(count($array) > 1) {
     $range = range(0.5, 1, .05);
     foreach ($range as $percentile) {
         $json[] = (object)[

--- a/src/Hal/Report/Html/template/oop.php
+++ b/src/Hal/Report/Html/template/oop.php
@@ -9,8 +9,8 @@ foreach ($classes as $c) {
         array_push($lcom, $c['lcom']);
     }
 }
-if (sizeof($lcom) > 0) {
-    $lcom = round(array_sum($lcom) / sizeof($lcom), 2);
+if (count($lcom) > 0) {
+    $lcom = round(array_sum($lcom) / count($lcom), 2);
 } else {
     $lcom = 0;
 }
@@ -23,7 +23,7 @@ if (sizeof($lcom) > 0) {
                 <div class="label">classes <?php echo $this->getTrend('sum', 'nbClasses'); ?></div>
                 <div class="number">
                     <?php echo $sum->nbClasses; ?>
-                    <small> (<?php echo (sizeof($classes) ? round($sum->nbClasses / sizeof($classes) * 100) : '0'); ?> %)</small>
+                    <small> (<?php echo (count($classes) ? round($sum->nbClasses / count($classes) * 100) : '0'); ?> %)</small>
                 </div>
             </div>
         </div>
@@ -31,7 +31,7 @@ if (sizeof($lcom) > 0) {
             <div class="bloc bloc-number">
                 <div class="label">interfaces <?php echo $this->getTrend('sum', 'nbInterfaces'); ?></div>
                 <div class="number"><?php echo $sum->nbInterfaces; ?>
-                    <small> (<?php echo (sizeof($classes) ? round($sum->nbInterfaces / sizeof($classes) * 100) : '0'); ?> %)</small>
+                    <small> (<?php echo (count($classes) ? round($sum->nbInterfaces / count($classes) * 100) : '0'); ?> %)</small>
                 </div>
             </div>
         </div>

--- a/src/Hal/Report/Html/template/panel.php
+++ b/src/Hal/Report/Html/template/panel.php
@@ -13,7 +13,7 @@ require __DIR__ . '/_header.php'; ?>
             <div class="bloc bloc-number">
                 <div class="number">
                     <?php echo $sum->nbClasses; ?>
-                    <small> (<?php echo(sizeof($classes) ? round($sum->nbClasses / sizeof($classes) * 100) : '0'); ?>
+                    <small> (<?php echo(count($classes) ? round($sum->nbClasses / count($classes) * 100) : '0'); ?>
                         %)
                     </small>
                 </div>
@@ -23,7 +23,7 @@ require __DIR__ . '/_header.php'; ?>
         <div class="column">
             <div class="bloc bloc-number">
                 <div class="number"><?php echo $sum->nbInterfaces; ?>
-                    <small> (<?php echo(sizeof($classes) ? round($sum->nbInterfaces / sizeof($classes) * 100) : '0'); ?>
+                    <small> (<?php echo(count($classes) ? round($sum->nbInterfaces / count($classes) * 100) : '0'); ?>
                         %)
                     </small>
                 </div>

--- a/src/Hal/Report/Html/template/violations.php
+++ b/src/Hal/Report/Html/template/violations.php
@@ -56,7 +56,7 @@ $map = [
                     </thead>
                     <tbody>
                     <?php foreach ($classes as $class) {
-                        if (sizeof($class['violations']) > 0) {
+                        if (count($class['violations']) > 0) {
                             $currentId = 'bloc-' . uniqid('', true);
                             ?>
 
@@ -107,7 +107,7 @@ $map = [
                     </thead>
                     <tbody>
                     <?php foreach ($packages as $package) {
-                        if (sizeof($package['violations']) > 0) {
+                        if (count($package['violations']) > 0) {
                             $currentId = 'bloc-' . uniqid();
                             ?>
 

--- a/src/Hal/Report/Violations/Xml/Reporter.php
+++ b/src/Hal/Report/Violations/Xml/Reporter.php
@@ -57,7 +57,7 @@ class Reporter
 
         foreach ($metrics->all() as $metric) {
             $violations = $metric->get('violations');
-            if (sizeof($violations) == 0) {
+            if (count($violations) == 0) {
                 continue;
             }
 

--- a/src/Hal/Violation/Class_/Blob.php
+++ b/src/Hal/Violation/Class_/Blob.php
@@ -37,7 +37,7 @@ class Blob implements Violation
             $suspect++;
         }
 
-        if (sizeof($metric->get('externals')) >= 8) {
+        if (count($metric->get('externals')) >= 8) {
             $suspect++;
         }
 

--- a/src/Hal/Violation/Violations.php
+++ b/src/Hal/Violation/Violations.php
@@ -34,7 +34,7 @@ class Violations implements \IteratorAggregate, \Countable
      */
     public function count()
     {
-        return sizeof($this->data);
+        return count($this->data);
     }
 
     /**

--- a/src/functions.php
+++ b/src/functions.php
@@ -75,7 +75,7 @@ function iterate_over_node($node, $callback)
     $myVisitor = new MyVisitor($callback);
     $traverser = new \PhpParser\NodeTraverser();
     $traverser->addVisitor($myVisitor);
-    $traverser->traverse(array($node));
+    $traverser->traverse([$node]);
     return;
 }
 

--- a/tests/Component/Tree/NodeTest.php
+++ b/tests/Component/Tree/NodeTest.php
@@ -19,7 +19,7 @@ class NodeTest extends \PHPUnit_Framework_TestCase {
         $node->setData('value1');
 
         $this->assertEquals('value1', $node->getData());
-        $this->assertEquals(array('B' => $to), $node->getAdjacents());
+        $this->assertEquals(['B' => $to], $node->getAdjacents());
         $this->assertEquals('A', $node->getKey());
 
     }

--- a/tests/Metric/Class_/Component/MaintainabilityIndexVisitorTest.php
+++ b/tests/Metric/Class_/Component/MaintainabilityIndexVisitorTest.php
@@ -54,11 +54,11 @@ EOT;
     }
 
     public function provideValues() {
-        return array(
+        return [
             //    CC    LLOC    CLOC        Volume      MIwoC      mi          commentWeight
-            array(5     , 50    , 20       , 10         , 55.26,   92.1,      36.83 ),
-            array(11    , 45   , 26       , 1777.49    , 39.7,     80.01,      40.3 )
-        );
+            [5     , 50    , 20       , 10         , 55.26,   92.1,      36.83 ],
+            [11    , 45   , 26       , 1777.49    , 39.7,     80.01,      40.3 ]
+        ];
     }
 
 }

--- a/tests/Metric/examples/cyclomatic1.php
+++ b/tests/Metric/examples/cyclomatic1.php
@@ -38,7 +38,7 @@ class B {
 
         }
 
-        foreach(array() as $foo) {
+        foreach([] as $foo) {
             if(false) {
                 continue;
             }

--- a/tests/Metric/examples/cyclomatic_full.php
+++ b/tests/Metric/examples/cyclomatic_full.php
@@ -40,7 +40,7 @@ class Loops // ccn2: 5
             do {
             } while (false);
         }
-        foreach (array() as $each) {
+        foreach ([] as $each) {
             for ($i = 0; $i < 0; ++$i) {
             }
         }


### PR DESCRIPTION
This is the first PR to include codesniffer.

For now it has two simple rules.
- Remove alias functions
- Remove short array syntax.