### PR TITLE
Bump php package required

### DIFF
--- a/artifacts/debian/control
+++ b/artifacts/debian/control
@@ -10,7 +10,7 @@ Homepage: http://www.phpmetrics.org
 
 Package: phpmetrics
 Architecture: all
-Depends: php5 (>= 5.4.0+)
+Depends: php-cli (>= 7.0.0+)
 Description: Static analyzer for PHP
   PhpMetrics provides informations and charts about quality, complexity, maintainability... of your
   PHP code. Its supports any PHP code from PHP 5.3 to PHP 7


### PR DESCRIPTION
php5 is not available anymore in debian repository.
Using php-cli let to have the latest php version in the debian system that is php7>= https://packages.debian.org/stretch/php-cli installed on the system.