### PR TITLE
include the root directory when looking for composer.lock

### DIFF
--- a/src/Hal/Metric/System/Packages/Composer/Composer.php
+++ b/src/Hal/Metric/System/Packages/Composer/Composer.php
@@ -102,7 +102,10 @@ class Composer
 
         // Find composer.lock file
         $finder = new Finder(['lock'], $this->config->get('exclude'));
-        $files = $finder->fetch($this->config->get('files'));
+
+        // include root dir by default
+        $files = array_merge($this->config->get('files'), ['./']);
+        $files = $finder->fetch($files);
 
         // List all composer.lock found in the project.
         foreach ($files as $filename) {


### PR DESCRIPTION
Commit [6dfa587d9d13e0d0daaeab3fa91f10fc347495a6](https://github.com/phpmetrics/PhpMetrics/commit/6dfa587d9d13e0d0daaeab3fa91f10fc347495a6) explicitly added the package's root directory to the list when searching for `composer.json`. This patch does the same for `composer.lock`. Without this patch, the Composer section of the report shows `This package should be updated` for all packages, because the `composer.lock` will not be found and the current version of each package can not be determined. (Unless you've got your `composer.lock` file in a source directory, which is not likely.)