### PR TITLE
Allow usage behind proxy

### DIFF
--- a/src/Hal/Metric/System/Packages/Composer/Packagist.php
+++ b/src/Hal/Metric/System/Packages/Composer/Packagist.php
@@ -89,13 +89,13 @@ class Packagist
     {
         // Get the environment variable.
         $httpsProxy = getenv('https_proxy');
-        $context    = null;
+        $context = null;
         if ('' !== $httpsProxy) {
             // Create the context.
             $context = stream_context_create(
                 [
                     'http' => [
-                        'proxy' => $this->tcpProtocol($httpsProxy),
+                        'proxy' => str_replace(['http://', 'https://'], 'tcp://', $httpsProxy),
                         'request_fulluri' => true,
                     ],
                 ]
@@ -103,25 +103,5 @@ class Packagist
         }
 
         return json_decode(@file_get_contents($uri, false, $context));
-    }
-
-    /**
-     * Replace http or https protocols with tcp for creating the stream context.
-     *
-     * @param string $httpsProxy
-     *
-     * @return string
-     */
-    private function tcpProtocol($httpsProxy)
-    {
-        return str_replace(
-            'https://',
-            'tcp://',
-            str_replace(
-                'http://',
-                'tcp://',
-                $httpsProxy
-            )
-        );
     }
 }

--- a/src/Hal/Metric/System/Packages/Composer/Packagist.php
+++ b/src/Hal/Metric/System/Packages/Composer/Packagist.php
@@ -87,35 +87,41 @@ class Packagist
      */
     private function getURIContentAsJson($uri)
     {
-        // get the json file
+        // Get the environment variable.
         $httpsProxy = getenv('https_proxy');
+        $context    = null;
         if ('' !== $httpsProxy) {
-            $tcpProxy = str_replace(
-                'https://',
-                'tcp://',
-                str_replace(
-                    'http://',
-                    'tcp://',
-                    $httpsProxy
-                )
-            );
+            // Create the context.
             $context = stream_context_create(
                 [
                     'http' => [
-                        'proxy'           => $tcpProxy,
+                        'proxy' => $this->tcpProtocol($httpsProxy),
                         'request_fulluri' => true,
                     ],
                 ]
             );
-            return json_decode(
-                @file_get_contents(
-                    $uri,
-                    false,
-                    $context
-                )
-            );
-        } else {
-            return json_decode(@file_get_contents($uri));
         }
+
+        return json_decode(@file_get_contents($uri, false, $context));
+    }
+
+    /**
+     * Replace http or https protocols with tcp for creating the stream context.
+     *
+     * @param string $httpsProxy
+     *
+     * @return string
+     */
+    private function tcpProtocol($httpsProxy)
+    {
+        return str_replace(
+            'https://',
+            'tcp://',
+            str_replace(
+                'http://',
+                'tcp://',
+                $httpsProxy
+            )
+        );
     }
 }

--- a/src/Hal/Metric/System/Packages/Composer/Packagist.php
+++ b/src/Hal/Metric/System/Packages/Composer/Packagist.php
@@ -36,7 +36,7 @@ class Packagist
         }
         list($user, $name) = explode('/', $package);
         $uri = sprintf('https://packagist.org/packages/%s/%s.json', $user, $name);
-        $json = json_decode(@file_get_contents($uri));
+        $json = getURIContentAsJson($uri);
 
         if (!isset($json->package) || !is_object($json->package)) {
             return $response;

--- a/src/functions.php
+++ b/src/functions.php
@@ -227,3 +227,32 @@ function percentile($arr, $percentile = 0.95)
     sort($arr);
     return $arr[max(round($percentile * count($arr) - 1.0 - $percentile), 0)];
 }
+
+/**
+ * Download the given URI and decode it as JSON.
+ * @param string $uri
+ *
+ * @return mixed
+ */
+function getURIContentAsJson($uri){
+    // get the json file
+    $httpsProxy = getenv('https_proxy');
+    if (!empty($httpsProxy)) {
+        return json_decode(@file_get_contents($uri, false, [
+            'http' => [
+                'proxy'           => str_replace(
+                    'https://',
+                    'tcp://',
+                    str_replace(
+                        'http://',
+                        'tcp://',
+                        $httpsProxy
+                    )
+                ),
+                'request_fulluri' => true,
+            ],
+        ]));
+    } else {
+        return json_decode(@file_get_contents($uri));
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -227,32 +227,3 @@ function percentile($arr, $percentile = 0.95)
     sort($arr);
     return $arr[max(round($percentile * count($arr) - 1.0 - $percentile), 0)];
 }
-
-/**
- * Download the given URI and decode it as JSON.
- * @param string $uri
- *
- * @return mixed
- */
-function getURIContentAsJson($uri){
-    // get the json file
-    $httpsProxy = getenv('https_proxy');
-    if (!empty($httpsProxy)) {
-        return json_decode(@file_get_contents($uri, false, [
-            'http' => [
-                'proxy'           => str_replace(
-                    'https://',
-                    'tcp://',
-                    str_replace(
-                        'http://',
-                        'tcp://',
-                        $httpsProxy
-                    )
-                ),
-                'request_fulluri' => true,
-            ],
-        ]));
-    } else {
-        return json_decode(@file_get_contents($uri));
-    }
-}


### PR DESCRIPTION
It reads environment variable `http_proxy` before trying to download the composer.json dependency from `Packagist` and creates a stream context to download it if it was configured.

Typically, if you are trying to analyze your code behind a proxy, this tool is stuck getting the packagist dependency tree for all the project dependencies. With this change, its success to download them and move on with the analysis.