### PR TITLE
Fixed issue with incorrect table header on the complexity report

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
     "require-dev": {
         "phpunit/phpunit": "^4.8.36 || ^5.7.27 || ^6.5.14",
         "sebastian/comparator": ">=1.2.3",
-        "squizlabs/php_codesniffer": "^3.5"
+        "squizlabs/php_codesniffer": "^3.5",
+        "symfony/dom-crawler": "^3.0 || ^4.0 || ^5.0"
     },
     "bin": [
         "bin/phpmetrics"

--- a/templates/html_report/complexity.php
+++ b/templates/html_report/complexity.php
@@ -75,7 +75,7 @@ require __DIR__ . '/_header.php'; ?>
                             <td><span class="path"><?php echo $class['name']; ?></span></td>
                             <?php foreach (['wmc', 'ccn', 'ccnMethodMax', 'relativeSystemComplexity', 'relativeDataComplexity', 'relativeStructuralComplexity', 'bugs', 'kanDefect'] as $attribute) {?>
                                 <td>
-                                    <span class="badge" <?php echo gradientStyleFor($classes, $attribute, $class[$attribute]);?>);">
+                                    <span class="badge" <?php echo gradientStyleFor($classes, $attribute, $class[$attribute]);?>>
                                     <?php echo isset($class[$attribute]) ? $class[$attribute] : ''; ?>
                                     </span>
                                 </td>

--- a/templates/html_report/complexity.php
+++ b/templates/html_report/complexity.php
@@ -59,13 +59,14 @@ require __DIR__ . '/_header.php'; ?>
                         <th class="js-sort-number">WMC</th>
                         <th class="js-sort-number">Class cycl.</th>
                         <th class="js-sort-number">Max method cycl.</th>
+                        <th class="js-sort-number">Relative system complexity</th>
                         <th class="js-sort-number">Relative data complexity</th>
                         <th class="js-sort-number">Relative structural complexity</th>
                         <th class="js-sort-number">Bugs</th>
                         <th class="js-sort-number">Defects</th>
                         <?php if ($config->has('junit')) { ?>
                             <th class="js-sort-number">Unit testsuites calling it</th>
-                        <?php } ?><th class="js-sort-number">Relative system complexity</th>
+                        <?php } ?>
                     </tr>
                     </thead>
                     <?php

--- a/templates/html_report/coupling.php
+++ b/templates/html_report/coupling.php
@@ -26,7 +26,7 @@
                         <td><span class="path"><?php echo $class['name']; ?></span></td>
                         <?php foreach (['afferentCoupling', 'efferentCoupling', 'instability', 'pageRank'] as $attribute) {?>
                             <td>
-                                <span class="badge" <?php echo gradientStyleFor($classes, $attribute, $class[$attribute]);?>);">
+                                <span class="badge" <?php echo gradientStyleFor($classes, $attribute, $class[$attribute]);?>>
                                 <?php echo isset($class[$attribute]) ? $class[$attribute] : ''; ?>
                                 </span>
                             </td>

--- a/templates/html_report/index.php
+++ b/templates/html_report/index.php
@@ -154,7 +154,7 @@ require __DIR__ . '/_header.php'; ?>
                             foreach ($classesS as $class) { ?>
                                 <tr>
                                     <td>
-                                        <span class="badge" <?php echo gradientStyleFor($classes, 'pageRank', $class['pageRank']);?>);">
+                                        <span class="badge" <?php echo gradientStyleFor($classes, 'pageRank', $class['pageRank']);?>>
                                         <?php echo $class['pageRank']; ?>
                                     </td>
                                     </td>

--- a/templates/html_report/junit.php
+++ b/templates/html_report/junit.php
@@ -82,7 +82,7 @@ $getMetricForClass = function ($classname, $metric) use ($classes) {
                                 <td><span class="path"><?php echo $class['name']; ?></span></td>
                                 <?php foreach (['ccn', 'bugs'] as $attribute) {?>
                                     <td>
-                                        <span class="badge" <?php echo gradientStyleFor($classes, $attribute, $class[$attribute]);?>);">
+                                        <span class="badge" <?php echo gradientStyleFor($classes, $attribute, $class[$attribute]);?>>
                                         <?php echo isset($class[$attribute]) ? $class[$attribute] : ''; ?>
                                         </span>
                                     </td>

--- a/templates/html_report/loc.php
+++ b/templates/html_report/loc.php
@@ -57,7 +57,7 @@ if(count($array) > 1) {
                         <td><span class="path"><?php echo $class['name']; ?></span></td>
                         <?php foreach (['lloc', 'cloc', 'volume', 'intelligentContent', 'commentWeight'] as $attribute) {?>
                             <td>
-                                <span class="badge" <?php echo gradientStyleFor($classes, $attribute, $class[$attribute]);?>);">
+                                <span class="badge" <?php echo gradientStyleFor($classes, $attribute, $class[$attribute]);?>>
                                 <?php echo isset($class[$attribute]) ? $class[$attribute] : ''; ?>
                                 </span>
                             </td>

--- a/templates/html_report/oop.php
+++ b/templates/html_report/oop.php
@@ -77,7 +77,7 @@ if (count($lcom) > 0) {
                             <td><span class="path"><?php echo $class['name']; ?></span></td>
                             <?php foreach (['lcom', 'volume', 'ccn', 'ccnMethodMax', 'bugs', 'difficulty'] as $attribute) {?>
                                 <td>
-                                    <span class="badge" <?php echo gradientStyleFor($classes, $attribute, $class[$attribute]);?>);">
+                                    <span class="badge" <?php echo gradientStyleFor($classes, $attribute, $class[$attribute]);?>>
                                     <?php echo isset($class[$attribute]) ? $class[$attribute] : ''; ?>
                                     </span>
                                 </td>

--- a/tests/Report/Html/ComplexityReportRegressionTest.php
+++ b/tests/Report/Html/ComplexityReportRegressionTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Test\Hal\Reporter\Html;
+
+use DOMNode;
+use Hal\Application\Config\Config;
+use Hal\Component\Output\TestOutput;
+use Hal\Metric\Group\Group;
+use Hal\Metric\Metrics;
+use Hal\Report\Html\Reporter;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DomCrawler\Crawler;
+
+/**
+ * @group reporter
+ * @group html
+ */
+class ComplexityReportRegressionTest extends TestCase
+{
+    /**
+     * @dataProvider tableHeaderDataProvider
+     */
+    public function testComplexityHtmlReportContainsCorrectOrderOfTableColumns($junitEnabled, $expectedTableHeader)
+    {
+        $config = new Config();
+        $output = new TestOutput();
+        $reporter = new Reporter($config, $output);
+
+        // prepares data for report
+        $groups = [];
+        $groups[] = new Group('group', '.*');
+        $config->set('groups', $groups);
+
+        if ($junitEnabled) {
+            $config->set('junit', ['file' => '/tmp/junit.xml']);
+        }
+
+        // prepares destination
+        $destination = implode(DIRECTORY_SEPARATOR, [
+            sys_get_temp_dir(),
+            'phpmetrics-html' . uniqid('', true)
+        ]);
+
+        $config->set('report-html', $destination);
+
+        // generates report
+        $metrics = new Metrics();
+        $reporter->generate($metrics);
+
+        // ensure complexity report contains expected table header columns
+        $content = file_get_contents(sprintf('%s/complexity.html', $destination));
+        $actualTableHeader = $this->getActualTableHeader($content);
+
+        $this->assertEquals($expectedTableHeader, $actualTableHeader);
+    }
+
+    public function tableHeaderDataProvider()
+    {
+        $defaultTableHeader = [
+            'Class',
+            'WMC',
+            'Class cycl.',
+            'Max method cycl.',
+            'Relative system complexity',
+            'Relative data complexity',
+            'Relative structural complexity',
+            'Bugs',
+            'Defects',
+        ];
+
+        $junitTableHeader = array_merge($defaultTableHeader, [
+            'Unit testsuites calling it'
+        ]);
+
+        return [
+            'junit disabled' => [false, $defaultTableHeader],
+            'junit enabled' => [true, $junitTableHeader],
+        ];
+    }
+
+    private function getActualTableHeader($content)
+    {
+        $tableHeaderColumnNodes = (new Crawler($content))
+            ->filterXPath('.//table[contains(concat(" ",normalize-space(@class)," ")," js-sort-table ")]/thead/tr')
+            ->children();
+
+        return array_map(function (DomNode $node) {
+            return $node->textContent;
+        }, iterator_to_array($tableHeaderColumnNodes));
+    }
+}


### PR DESCRIPTION
PR #421 accidentally moved the column "Relative system complexity" to the end of the table header causing an issue where the order of the header columns don't match the order of the data columns. A unit test has been added to validate the expected order of the columns.

Before:
![Screenshot 2021-09-19 at 17 12 30](https://user-images.githubusercontent.com/82103515/133935578-847d4168-b396-464d-87a3-264b36eeaf66.png)

After:
![Screenshot 2021-09-19 at 17 09 30](https://user-images.githubusercontent.com/82103515/133935584-ef0989ef-7821-4f94-bc3d-a10dd243de89.png)

Note that in the second image the data values for "Bugs" and "Defects" are correctly displayed in their corresponding column.
