### PR TITLE
Remove php8.1 deprecations

### DIFF
--- a/src/Hal/Component/File/Finder.php
+++ b/src/Hal/Component/File/Finder.php
@@ -39,22 +39,13 @@ class Finder
     private $excludedDirs = [];
 
     /**
-     * Flags for RecursiveDirectoryIterator
-     *
-     * @var integer
-     */
-    private $flags;
-
-    /**
      * @param string[] $extensions   regex of file extensions to include
      * @param string[] $excludedDirs regex of directories to exclude
-     * @param int $flags
      */
-    public function __construct(array $extensions = ['php'], array $excludedDirs = [], $flags = null)
+    public function __construct(array $extensions = ['php'], array $excludedDirs = [])
     {
         $this->extensions = $extensions;
         $this->excludedDirs = $excludedDirs;
-        $this->flags = $flags;
     }
 
     /**
@@ -69,7 +60,7 @@ class Finder
         foreach ($paths as $path) {
             if (is_dir($path)) {
                 $path = rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
-                $directory = new RecursiveDirectoryIterator($path, $this->flags);
+                $directory = new RecursiveDirectoryIterator($path);
                 $iterator = new RecursiveIteratorIterator($directory);
 
                 $filterRegex = sprintf(

--- a/src/Hal/Component/Tree/Graph.php
+++ b/src/Hal/Component/Tree/Graph.php
@@ -100,6 +100,7 @@ class Graph implements \Countable
     /**
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->data);

--- a/src/Hal/Metric/BagTrait.php
+++ b/src/Hal/Metric/BagTrait.php
@@ -79,6 +79,7 @@ trait BagTrait
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array_merge($this->all(), ['_type' => get_class($this)]);

--- a/src/Hal/Metric/Metrics.php
+++ b/src/Hal/Metric/Metrics.php
@@ -52,6 +52,7 @@ class Metrics implements \JsonSerializable
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->all();

--- a/src/Hal/Metric/System/Packages/Composer/Composer.php
+++ b/src/Hal/Metric/System/Packages/Composer/Composer.php
@@ -42,12 +42,17 @@ class Composer
         $packagist = new Packagist();
         foreach ($rawRequirements as $requirement => $version) {
             $installed = isset($rawInstalled[$requirement]) ? $rawInstalled[$requirement] : null;
-            $package = $packagist->get($requirement, $installed);
+            $package = $packagist->get($requirement);
 
             $package->installed = $installed;
             $package->required = $version;
             $package->name = $requirement;
-            $package->status = version_compare($installed, $package->latest, '<') ? 'outdated' : 'latest';
+            // Manage case where the package is not hosted on packagist (private repository) so we can't know the status
+            if ($installed === null || $package->latest === null) {
+                $package->status = 'unknown';
+            } else {
+                $package->status = version_compare($installed, $package->latest, '<') ? 'outdated' : 'latest';
+            }
             $packages[$requirement] = $package;
         }
 

--- a/src/Hal/Violation/Violations.php
+++ b/src/Hal/Violation/Violations.php
@@ -14,6 +14,7 @@ class Violations implements \IteratorAggregate, \Countable
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->data);
@@ -30,6 +31,7 @@ class Violations implements \IteratorAggregate, \Countable
     /**
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->data);

--- a/templates/html_report/composer.php
+++ b/templates/html_report/composer.php
@@ -29,6 +29,8 @@ if ([] === $packages) {
                             <div class="help-inner">
                                 <?php if ('outdated' === $package->status) { ?>
                                     <span class="help-warning" style="position: absolute; right: 10px;">This package should be updated.</span>
+                                <?php } elseif ('unknown' === $package->status) { ?>
+                                    <span class="help-info" style="position: absolute; right: 10px;">This package is private.</span>
                                 <?php } ?>
                                 <span class="badge"><?php echo $package->type; ?></span>
                                 <?php echo $package->description; ?>

--- a/templates/html_report/css/style.css
+++ b/templates/html_report/css/style.css
@@ -700,3 +700,6 @@ footer {
 .help-warning {
     background-color: #fbd38d;
 }
+.help-info {
+    background-color:#A7F9FC;
+}


### PR DESCRIPTION
After some tests with PHP 8.1, I have some deprecation errors, mainly due to [this RFC](https://wiki.php.net/rfc/internal_method_return_types), but also because of a stricter type check internally done by PHP now.

There are 3 commits for 3 different kind of resolutions depending on the issues.

1. I removed the usage of the "flag" filter for the Finder, as it was never set, so always `null`, while an integer is expected.
2. I added the PHP Attribute `#[ReturnTypeWillChange]` on all methods that implement a PHP internal method. This is because they now need to have the expected return type defined, but as PhpMetrics is still compatible with PHP >= 5.5 and return type definitions are PHP >= 7, we can't provide the expected fix. We need to drop the support of PHP 5.5 and PHP 5.6 minimum to fix this correctly (and it will be necessary for PHP 9). While PHP Attributes are PHP 8 only, their syntax allows their usages in PHP < 8 as they'll just be parsed as comments, so there's no side effects. On PHP 8.0, this attribute has no effect neither.
3. I added the "unknown" status along side "outdated" or "latest" for composer packages that are private. As we can't get more information on them, it would caused "installed" and "latest" values set to `null`, which broke the usage of `version_compare` to set the right status on the package. This new "unknown" status has been added to the UI too, and it declares the package as a private package, with a light-blue backgound, on the opposite of the orange background when a package is outdated.

If you have any remarks, please tell me. I'll see how this could be improved ASAP as PHP 8.1 is being released today.