### PR TITLE
Add command to get summary as Json

### DIFF
--- a/src/Hal/Application/Application.php
+++ b/src/Hal/Application/Application.php
@@ -68,6 +68,7 @@ class Application
         (new Report\Html\Reporter($config, $output))->generate($metrics);
         (new Report\Csv\Reporter($config, $output))->generate($metrics);
         (new Report\Json\Reporter($config, $output))->generate($metrics);
+        (new Report\Json\SummaryReporter($config, $output))->generate($metrics);
         (new Report\Violations\Xml\Reporter($config, $output))->generate($metrics);
 
         // end

--- a/src/Hal/Application/Config/Validator.php
+++ b/src/Hal/Application/Config/Validator.php
@@ -54,7 +54,7 @@ class Validator
         $config->set('groups', $groups);
 
         // parameters with values
-        $keys = ['report-html', 'report-csv', 'report-violation', 'report-json', 'extensions', 'config'];
+        $keys = ['report-html', 'report-csv', 'report-violation', 'report-json', 'report-summary-json', 'extensions', 'config'];
         foreach ($keys as $key) {
             $value = $config->get($key);
             if ($config->has($key) && empty($value) || true === $value) {
@@ -85,6 +85,7 @@ Optional:
     --report-html=<directory>         Folder where report HTML will be generated
     --report-csv=<file>               File where report CSV will be generated
     --report-json=<file>              File where report Json will be generated
+    --report-summary-json=<file>      File where the summary report Json will be generated
     --report-violations=<file>        File where XML violations report will be generated
     --git[=</path/to/git_binary>]     Perform analyses based on Git History (default binary path: "git")
     --junit[=</path/to/junit.xml>]    Evaluates metrics according to JUnit logs

--- a/src/Hal/Report/Cli/SummaryWriter.php
+++ b/src/Hal/Report/Cli/SummaryWriter.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Hal\Report\Cli;
+
+use Hal\Report\SummaryProvider;
+
+class SummaryWriter extends SummaryProvider
+{
+    public function getReport()
+    {
+        $out = <<<EOT
+LOC
+    Lines of code                               {$this->sum->loc}
+    Logical lines of code                       {$this->sum->lloc}
+    Comment lines of code                       {$this->sum->cloc}
+    Average volume                              {$this->avg->volume}
+    Average comment weight                      {$this->avg->commentWeight}
+    Average intelligent content                 {$this->avg->commentWeight}
+    Logical lines of code by class              {$this->locByClass}
+    Logical lines of code by method             {$this->locByMethod}
+Object oriented programming
+    Classes                                     {$this->sum->nbClasses}
+    Interface                                   {$this->sum->nbInterfaces}
+    Methods                                     {$this->sum->nbMethods}
+    Methods by class                            {$this->methodsByClass}
+    Lack of cohesion of methods                 {$this->avg->lcom}
+
+Coupling
+    Average afferent coupling                   {$this->avg->afferentCoupling}
+    Average efferent coupling                   {$this->avg->efferentCoupling}
+    Average instability                         {$this->avg->instability}
+    Depth of Inheritance Tree                   {$this->treeInheritenceDepth}
+
+Package
+    Packages                                    {$this->sum->nbPackages}
+    Average classes per package                 {$this->avg->classesPerPackage}
+    Average distance                            {$this->avg->distance}
+    Average incoming class dependencies         {$this->avg->incomingCDep}
+    Average outgoing class dependencies         {$this->avg->outgoingCDep}
+    Average incoming package dependencies       {$this->avg->incomingPDep}
+    Average outgoing package dependencies       {$this->avg->outgoingPDep}
+Complexity
+    Average Cyclomatic complexity by class      {$this->avg->ccn}
+    Average Weighted method count by class      {$this->avg->wmc}
+    Average Relative system complexity          {$this->avg->relativeSystemComplexity}
+    Average Difficulty                          {$this->avg->difficulty}
+
+Bugs
+    Average bugs by class                       {$this->avg->bugs}
+    Average defects by class (Kan)              {$this->avg->kanDefect}
+Violations
+    Critical                                    {$this->sum->violations->critical}
+    Error                                       {$this->sum->violations->error}
+    Warning                                     {$this->sum->violations->warning}
+    Information                                 {$this->sum->violations->information}
+EOT;
+
+        // git
+        if ($this->config->has('git')) {
+            $commits = [];
+            foreach ($this->consolidated->getFiles() as $name => $file) {
+                $commits[$name] = $file['gitChanges'];
+            }
+            arsort($commits);
+            $commits = array_slice($commits, 0, 10);
+
+            $out .= "\nTop 10 committed files";
+            foreach ($commits as $file => $nb) {
+                $out .= sprintf("\n    %d    %s", $nb, $file);
+            }
+            if (0 === count($commits)) {
+                $out .= "\n    NA";
+            }
+            $out .= "\n";
+        }
+
+        // Junit
+        if ($this->config->has('junit')) {
+            $out .= <<<EOT
+
+Unit testing
+    Number of unit tests                        {$this->metrics->get('unitTesting')->get('nbSuites')}
+    Classes called by tests                     {$this->metrics->get('unitTesting')->get('nbCoveredClasses')}
+    Classes called by tests (percent)           {$this->metrics->get('unitTesting')->get('percentCoveredClasses')} %
+EOT;
+        }
+
+        $out .= "\n\n";
+
+        return $out;
+    }
+}

--- a/src/Hal/Report/Json/SummaryReporter.php
+++ b/src/Hal/Report/Json/SummaryReporter.php
@@ -1,14 +1,15 @@
 <?php
-namespace Hal\Report\Cli;
+
+namespace Hal\Report\Json;
 
 use Hal\Application\Config\Config;
 use Hal\Component\Output\Output;
 use Hal\Metric\Consolidated;
 use Hal\Metric\Metrics;
+use Hal\Report\SummaryProvider;
 
-class Reporter
+class SummaryReporter
 {
-
     /**
      * @var Config
      */
@@ -35,8 +36,15 @@ class Reporter
             return;
         }
 
-        $this->output->write(
-            (new SummaryWriter($metrics, new Consolidated($metrics), $this->config))->getReport()
-        );
+        $logFile = $this->config->get('report-summary-json');
+        if (!$logFile) {
+            return;
+        }
+        if (!file_exists(dirname($logFile)) || !is_writable(dirname($logFile))) {
+            throw new \RuntimeException('You don\'t have permissions to write JSON report in ' . $logFile);
+        }
+
+        $summaryWriter = new SummaryWriter($metrics, new Consolidated($metrics), $this->config);
+        file_put_contents($logFile, json_encode($summaryWriter->getReport(), JSON_PRETTY_PRINT));
     }
 }

--- a/src/Hal/Report/Json/SummaryWriter.php
+++ b/src/Hal/Report/Json/SummaryWriter.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Hal\Report\Json;
+
+use Hal\Report\SummaryProvider;
+
+class SummaryWriter extends SummaryProvider
+{
+    public function getReport()
+    {
+        return [
+            'LOC' => [
+                'linesOfCode' => $this->sum->loc,
+                'logicalLinesOfCode' => $this->sum->lloc,
+                'commentLinesOfCode' => $this->sum->cloc,
+                'avgVolume' => $this->avg->volume,
+                'avgCommentWeight' => $this->avg->commentWeight,
+                'avgIntelligentContent ' => $this->avg->commentWeight,
+                'logicalLinesByClass' => $this->locByClass,
+                'logicalLinesByMethod' => $this->locByMethod,
+            ],
+            'OOP' => [
+                'classes' => $this->sum->nbClasses,
+                'interface' => $this->sum->nbInterfaces,
+                'methods' => $this->sum->nbMethods,
+                'methodsByClass' => $this->methodsByClass,
+                'lackCohesionOfMethods' => $this->avg->lcom,
+            ],
+            'Coupling' => [
+                'avgAfferentCoupling' => $this->avg->afferentCoupling,
+                'avgEfferentCoupling' => $this->avg->efferentCoupling,
+                'avgInstability' => $this->avg->instability,
+                'inheritanceTreeDepth' => $this->treeInheritenceDepth,
+            ],
+            'Package' => [
+                'packages' => $this->sum->nbPackages,
+                'acgClassesPerPackage ' => $this->avg->classesPerPackage,
+                'avgDistance' => $this->avg->distance,
+                'avgIncomingClassDependencies' => $this->avg->incomingCDep,
+                'avgOutgoingClassDependencies' => $this->avg->outgoingCDep,
+                'avgIncomingPackageDependencies' => $this->avg->incomingPDep,
+                'avgOutgoingPackageDependencies' => $this->avg->outgoingPDep,
+            ],
+            'Complexity' => [
+                'avgCyclomaticComplexityByClass' => $this->avg->ccn,
+                'avgWeightedMethodCountByClass' => $this->avg->wmc,
+                'avgRelativeSystemComplexity' => $this->avg->relativeSystemComplexity,
+                'avgDifficulty' => $this->avg->difficulty,
+            ],
+            'Bugs' => [
+                'avgBugsByClass' => $this->avg->bugs,
+                'avgDefectsByClass' => $this->avg->kanDefect,
+            ],
+            'Violations' => [
+                'critical' => $this->sum->violations->critical,
+                'error' => $this->sum->violations->error,
+                'warning' => $this->sum->violations->warning,
+                'information' => $this->sum->violations->information,
+            ]
+        ];
+    }
+}

--- a/src/Hal/Report/SummaryProvider.php
+++ b/src/Hal/Report/SummaryProvider.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Hal\Report;
+
+use Hal\Application\Config\Config;
+use Hal\Metric\Consolidated;
+use Hal\Metric\Metrics;
+
+abstract class SummaryProvider
+{
+    /**
+     * @var int
+     */
+    protected $methodsByClass = 0;
+
+    /**
+     * @var int
+     */
+    protected $locByClass = 0;
+
+    /**
+     * @var int
+     */
+    protected $locByMethod = 0;
+
+    /**
+     * @var object
+     */
+    protected $sum;
+
+    /**
+     * @var object
+     */
+    protected $avg;
+
+    /**
+     * @var mixed
+     */
+    protected $treeInheritenceDepth;
+
+    /**
+     * @var Consolidated
+     */
+    protected $consolidated;
+
+    /**
+     * @var Config
+     */
+    protected $config;
+
+    /**
+     * @var Metrics
+     */
+    protected $metrics;
+
+    public function __construct(Metrics $metrics, Consolidated $consolidated, Config $config)
+    {
+        $this->consolidated = $consolidated;
+        $this->config = $config;
+        $this->metrics = $metrics;
+        $this->sum = $consolidated->getSum();
+        $this->avg = $consolidated->getAvg();
+
+        // grouping results
+        if ($this->sum->nbClasses > 0) {
+            $this->methodsByClass = round($this->sum->nbMethods / $this->sum->nbClasses, 2);
+            $this->locByClass = round($this->sum->lloc / $this->sum->nbClasses);
+        }
+        if ($this->sum->nbMethods > 0) {
+            $this->locByMethod = round($this->sum->lloc / $this->sum->nbMethods);
+        }
+
+        $this->treeInheritenceDepth = $metrics->get('tree')->get('depthOfInheritanceTree');
+    }
+
+    abstract public function getReport();
+}


### PR DESCRIPTION
I wanted to add the summary metrics of PHPMetrics to a build pipeline so I can send this data to a monitoring client to track changes over time.

 I did not find an easy way to do this, so I thought I would add a functionality to get the consolidated data as JSON.

![image](https://user-images.githubusercontent.com/5929622/144238484-bafb000e-6e2d-4a19-9e56-81bd4d8e174d.png)
