### PR TITLE
SystemComplexityVisitor for methods with the same name on different objects

### DIFF
--- a/src/Hal/Metric/Class_/Structural/SystemComplexityVisitor.php
+++ b/src/Hal/Metric/Class_/Structural/SystemComplexityVisitor.php
@@ -50,14 +50,26 @@ class SystemComplexityVisitor extends NodeVisitorAbstract
                     $output = 0;
                     $fanout = [];
 
-                    iterate_over_node($node, function ($node) use (&$output, &$fanout) {
+                    $parentNode = $node;
+                    iterate_over_node($node, function ($node) use (&$output, &$fanout, $parentNode) {
                         switch (true) {
                             case $node instanceof Stmt\Return_:
                                 $output++;
                                 break;
                             case $node instanceof Node\Expr\StaticCall:
+                                $class = getNameOfNode($node->class);
+                                if ('static' === $class || 'self' === $class) {
+                                    $class = getNameOfNode($parentNode);
+                                }
+                                $fanout[] = $class . '::' . getNameOfNode($node->name) . '()';
+                                break;
                             case $node instanceof Node\Expr\MethodCall:
-                                array_push($fanout, getNameOfNode($node));
+                                $class = getNameOfNode($node->var);
+                                if ('this' === $class) {
+                                    $class = getNameOfNode($parentNode);
+                                }
+                                $fanout[] = $class . '->' . getNameOfNode($node->name) . '()';
+                                break;
                         }
                     });
 

--- a/tests/Metric/Class_/Complexity/SystemComplexityVisitorTest.php
+++ b/tests/Metric/Class_/Complexity/SystemComplexityVisitorTest.php
@@ -38,7 +38,7 @@ class SystemComplexityVisitorTest extends \PHPUnit\Framework\TestCase
     public function provideExamples()
     {
         return [
-            [ __DIR__ . '/../../examples/systemcomplexity1.php', 'A', 2.5, 1.0, 3.5],
+            [ __DIR__ . '/../../examples/systemcomplexity1.php', 'A', 0.5, 36.0, 36.5],
         ];
     }
 }

--- a/tests/Metric/examples/systemcomplexity1.php
+++ b/tests/Metric/examples/systemcomplexity1.php
@@ -9,13 +9,47 @@ class A {
             return $b;
         }
 
+        self::bar();
+        static::bar();
+        $this->foo();
+
         (new B)->bar();
+        $B = new B;
+        $B->bar();
+        (new C)->bar();
+
+        $B::foo();
+        B::foo();
+        C::foo();
     }
 
+    public static function bar()
+    {
+
+    }
 }
 
 class B {
+
     public function bar()
+    {
+
+    }
+
+    public static function foo()
+    {
+
+    }
+}
+
+class C {
+
+    public function bar()
+    {
+
+    }
+
+    public static function foo()
     {
 
     }


### PR DESCRIPTION
`(new B)->bar()` and `(new C)->bar()` should be calculated separately.