### PR TITLE
Fix packagist array key type error

### DIFF
--- a/src/Hal/Metric/System/Packages/Composer/Packagist.php
+++ b/src/Hal/Metric/System/Packages/Composer/Packagist.php
@@ -67,7 +67,7 @@ final class Packagist implements ComposerRegistryConnectorInterface
         $latest = '0.0.0';
 
         foreach ((array)$json->package->versions as $version => $packageDataAtSpecificVersion) {
-            $version = ltrim($version, 'v');
+            $version = ltrim((string) $version, 'v');
             if (0 === preg_match('#^(\d|\.)+$#', $version) || version_compare($version, $latest, '<')) {
                 continue;
             }


### PR DESCRIPTION
- if there is an integer string set as a key of associative array, it will automatically be converted to integer, which causes the call of `ltrim` to fail, because of `declare(strict_types=1)` configuration
- this caused a runtime failure in my project