### PR TITLE
Support on nikic/php-parser v5.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "php": ">=5.5",
         "ext-dom": "*",
         "ext-tokenizer": "*",
-        "nikic/php-parser": "^3|^4"
+        "nikic/php-parser": "^3|^4|^5"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.36 || ^5.7.27 || ^6.5.14",


### PR DESCRIPTION
This is required for compatibility with other libraries to ensure that PHP 8.4 works.