### PR TITLE
Update Dockerfile: Replace MAINTAINER and Improve Cache Clearing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM php:8.4
 
-MAINTAINER "niconoe-" <nicolas.giraud.dev@gmail.com>
+LABEL org.opencontainers.image.authors="niconoe- <nicolas.giraud.dev@gmail.com>"
 
 COPY releases/phpmetrics.phar /usr/local/bin/phpmetrics
 
 RUN chmod +x /usr/local/bin/phpmetrics \
     # Install git to be able to use option "--git".
     && apt-get update && apt-get install -y git \
-    && rm -rf /var/cache/apk/* /var/tmp/* /tmp/*
+    && rm -rf /var/lib/apt/lists/*
 
 VOLUME ["/app"]
 WORKDIR /app


### PR DESCRIPTION
This pull request includes the following changes:

1. **Replacement of MAINTAINER Instruction**
   - Replaced the deprecated `MAINTAINER` instruction with `LABEL org.opencontainers.image.authors`.
   - For more details, see: [MAINTAINER Deprecated](https://docs.docker.com/reference/builder/#maintainer-deprecated)

2. **Clearing apt cache**
   - Reduced the image size by clearing the apt cache.

They do not impact the behavior of the application, so feel free to close this pull request if it's deemed unnecessary.
