### PR TITLE
fix: make sure var name is stringeable

### DIFF
--- a/src/Hal/Metric/Class_/Structural/LcomVisitor.php
+++ b/src/Hal/Metric/Class_/Structural/LcomVisitor.php
@@ -243,10 +243,14 @@ final class LcomVisitor extends NodeVisitorAbstract
         /** @var string|Node\Expr|Node\Identifier $nodeName */
         $nodeName = $node->name;
 
+        if ($nodeName instanceof Node\Scalar\String_) {
+            $nodeName = $nodeName->value;
+        }
+
         if (
             property_exists($node->var, 'name')
             && !($node->var->name instanceof Node\Expr\Variable)
-            && 'this' === ($node->var->name instanceof Stringable ? (string)$node->var->name : '')
+            && 'this' === (($node->var->name instanceof Stringable || is_string($node->var->name)) ? (string)$node->var->name : '')
             && ($nodeName instanceof Stringable || is_string($nodeName))
         ) {
             return (string)$nodeName;


### PR DESCRIPTION
When using an uncommon syntax like this:

```php
class Foo
{
    public function test(): void
    {
        $foo->{'bar.baz'}->children();
    }
}
```

There is a "Cannot parse foo.php" error.
The exact error is:
"Object of class PhpParser\Node\Scalar\String_ could not be converted to string"

I have fixed the related code, I'm not sure how to add a test though.

cc @niconoe-