### PR TITLE
Fix to avoid scanning the current directory for composer.json

### DIFF
--- a/src/Hal/Metric/System/Packages/Composer/Composer.php
+++ b/src/Hal/Metric/System/Packages/Composer/Composer.php
@@ -82,8 +82,7 @@ class Composer
         $finder = new Finder(['json'], $exclude);
 
         // include root dir by default
-        $files = $this->config->has('files') ? $this->config->get('files') : [];
-        $files = array_merge($files, ['./']);
+        $files = $this->config->has('files') ? $this->config->get('files') : ['./'];
         $files = $finder->fetch($files);
 
         foreach ($files as $filename) {
@@ -116,8 +115,7 @@ class Composer
         $finder = new Finder(['lock'], $exclude);
 
         // include root dir by default
-        $files = $this->config->has('files') ? $this->config->get('files') : [];
-        $files = array_merge($files, ['./']);
+        $files = $this->config->has('files') ? $this->config->get('files') : ['./'];
         $files = $finder->fetch($files);
 
         // List all composer.lock found in the project.


### PR DESCRIPTION
## Overview
By default, it recursively scans the current directory for composer.json and composer.lock.
When "files" are specified in the configuration, the scan should start from those directories, but it was also scanning the current directory.
This behavior has been fixed to scan from the specified directories when files are defined, and from the current directory when they are not.
Related issues: #463 #510

## Result
**.phpmetrics.json**
```xml
{
  "includes": [
    "app"
  ],
  "exclude": [
    "tests",
    "vendor",
    "docker"
  ],
  "report": {
    "html": "./tmp/php-metrics/report/",
    "csv": "./tmp/php-metrics/report.csv",
    "json": "./tmp/php-metrics/report.json",
    "violations": "./tmp/php-metrics/violations.xml"
  }
}
```

**Before Fix**
```sh
% ./vendor/bin/phpmetrics --config=./.phpmetrics.json


Executing system analyzes...

Executing composer analyzes, requesting https://packagist.org...PHP Fatal error:  Uncaught UnexpectedValueException: RecursiveDirectoryIterator::__construct(./docker): Failed to open directory: Permission denied in ...
```

**After Fix**
```sh
% ./vendor/bin/phpmetrics --config=./.phpmetrics.json


Executing system analyzes...

Executing composer analyzes, requesting https://packagist.org...

LOC
    Lines of code                               8
    Logical lines of code                       8
    Comment lines of code                       0
    Average volume                              0
    Average comment weight                      0
    Average intelligent content                 0
    Logical lines of code by class              8
    Logical lines of code by method             8
...
Done
```