### PR TITLE
fix trends not displayed correctly

### DIFF
--- a/src/Hal/Report/Html/Reporter.php
+++ b/src/Hal/Report/Html/Reporter.php
@@ -252,7 +252,7 @@ class Reporter
         }
 
         $oldValue = $last->$type->$key;
-        $newValue = isset($this->sum->$type->$key) ? $this->sum->$type->$key : 0;
+        $newValue = isset($this->$type->$key) ? $this->$type->$key : 0;
         if ($newValue > $oldValue) {
             $r = 'gt';
         } elseif ($newValue < $oldValue) {


### PR DESCRIPTION
PhpMetrics v2.9.1

Description:
Fixing trends not being displayed correctly.

Current behavior:
The trends in the html report will always show the current value and a trend of minus that value.

Correct behavior:
show actual trend change

Root cause:
`Hal\Report\Html\Reporter.php:255` checks for `isset($this->sum->$type->$key)` which will never be set, resulting in `$newValue` being assigned 0, causing the trend to be `0 - $oldValue`.

Fix:
Changing the lookup to `$this->$type->$key` from `$this->sum->$type->$key` checks for the correct variable.