### PR TITLE
fix wrong details link to oop page

### DIFF
--- a/templates/html_report/index.php
+++ b/templates/html_report/index.php
@@ -28,7 +28,7 @@ require __DIR__ . '/_header.php'; ?>
                 <div class="label"><a href="oop.html">Classes</a></div>
                 <div class="number"><?php echo number_format($sum->nbClasses, 0); ?></div>
                 <div class="bloc-action">
-                    <a href="loc.html">View details &gt;</a>
+                    <a href="oop.html">View details &gt;</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
PhpMetrics v2.9.1

Description:
The "View details" link for the "Classes" sections links to the wrong page

Current behavior:
The link sends the user to the wrong page

Correct behavior:
The "View details" link sends the user to the same page as the label

Fix:
Replace `loc.html` with `oop.html` in href