### PR TITLE
Import PhpParser Error class in PrepareParserTask

### DIFF
--- a/src/Hal/Application/Workflow/Task/PrepareParserTask.php
+++ b/src/Hal/Application/Workflow/Task/PrepareParserTask.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 namespace Hal\Application\Workflow\Task;
 
-use Error;
 use Hal\Component\File\ReaderInterface;
 use Hal\Component\Output\Output;
+use PhpParser\Error;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverserInterface;
 use PhpParser\Parser;


### PR DESCRIPTION
Fix that single file with a syntax error aborts the whole analysis and no report is generated. PhpParser\Error extends RuntimeException (i.e. it is an \Exception, not an \Error), so the catch clause never matches and the exception bubbles up, killing the run.

Steps to reproduce:
Create a project containing one valid PHP file and one file with invalid PHP. Real-world case — doptor/Doptor ships module templates with ***ROUTES*** placeholders inside .php files.