### PR TITLE
Fix PHP 8.2+ deprecation about dynamic property

### DIFF
--- a/src/Hal/Report/Html/Reporter.php
+++ b/src/Hal/Report/Html/Reporter.php
@@ -47,6 +47,41 @@ class Reporter
     private $assetPath = '';
 
     /**
+     * @var mixed
+     */
+    private $sum;
+
+    /**
+     * @var mixed
+     */
+    private $avg;
+
+    /**
+     * @var mixed
+     */
+    private $classes;
+
+    /**
+     * @var mixed
+     */
+    private $files;
+
+    /**
+     * @var mixed
+     */
+    private $project;
+
+    /**
+     * @var mixed
+     */
+    private $packages;
+
+    /**
+     * @var mixed
+     */
+    private $history;
+
+    /**
      * @param Config $config
      * @param Output $output
      */


### PR DESCRIPTION
Hi,

thanks for this project! While using it in some other project of mine with PHP 8.5 I found this deprecation. I thought it would be nice to have it in place to avoid unnecessary warning when using the tool. After all it makes nothing, just declaring the properties.

----

For PHP 8.2+ the usage of dynamics properties are already deprecated. This commit add the properties to the class declaration.