### PR TITLE
Fix tests warning and notices

### DIFF
--- a/src/Hal/Component/Tree/HashMap.php
+++ b/src/Hal/Component/Tree/HashMap.php
@@ -20,7 +20,7 @@ class HashMap implements \Countable, \IteratorAggregate
      * @param Node $node
      * @return $this
      */
-    public function attach(Node $node)
+    public function attach(Node $node): self
     {
         $this->nodes[$node->getKey()] = $node;
         return $this;
@@ -28,9 +28,9 @@ class HashMap implements \Countable, \IteratorAggregate
 
     /**
      * @param $key
-     * @return Node
+     * @return Node|null
      */
-    public function get($key)
+    public function get($key):? Node
     {
         return $this->has($key) ? $this->nodes[$key] : null;
     }
@@ -39,7 +39,7 @@ class HashMap implements \Countable, \IteratorAggregate
      * @param $key
      * @return bool
      */
-    public function has($key)
+    public function has($key): bool
     {
         return isset($this->nodes[$key]);
     }
@@ -47,7 +47,7 @@ class HashMap implements \Countable, \IteratorAggregate
     /**
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->nodes);
     }
@@ -55,7 +55,7 @@ class HashMap implements \Countable, \IteratorAggregate
     /**
      * @return \ArrayIterator
      */
-    public function getIterator()
+    public function getIterator(): \ArrayIterator
     {
         return new \ArrayIterator($this->nodes);
     }

--- a/src/Hal/Violation/Class_/Blob.php
+++ b/src/Hal/Violation/Class_/Blob.php
@@ -9,6 +9,11 @@ use Hal\Violation\Violation;
 class Blob implements Violation
 {
     /**
+     * @var \Hal\Metric\Metric
+     */
+    private $metric;
+
+    /**
      * @inheritdoc
      */
     public function getName()

--- a/tests/Component/Issuer/IssuerTest.php
+++ b/tests/Component/Issuer/IssuerTest.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace Test\Hal\Component\Issue;
+namespace Test\Hal\Component\Issuer;
 
 use Hal\Component\Ast\ParserFactoryBridge;
 use Hal\Component\Issue\Issuer;
 use Hal\Component\Output\TestOutput;
-use PhpParser\ParserFactory;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use Polyfill\TestCaseCompatible;
 
@@ -16,9 +15,9 @@ class IssuerTest extends \PHPUnit\Framework\TestCase
 {
     use TestCaseCompatible;
     /**
-     * @requires PHP < 7.0
+     * Test only for PHP < 7.0
      */
-    #[RequiresPhp('< 7.0')]
+    #[RequiresPhp('<7.0.0')]
     public function testICanEnableIssuerPhp5(): void
     {
         $output = new TestOutput();
@@ -39,11 +38,11 @@ class IssuerTest extends \PHPUnit\Framework\TestCase
         $issuer->disable();
     }
 
-    /**
-     * @requires PHP < 7.0
-     */
     public function testIssuerDisplayStatements(): void
     {
+        if (PHP_MAJOR_VERSION >= 7) {
+            $this->markTestSkipped('This test is only for PHP < 7.0');
+        }
         $output = new TestOutput();
         $issuer = (new TestIssuer($output))->enable();
         $code = <<<EOT

--- a/tests/Metric/System/UnitTesting/UnitTestingTest.php
+++ b/tests/Metric/System/UnitTesting/UnitTestingTest.php
@@ -27,8 +27,8 @@ class UnitTestingTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(7, $tests['Test\Hal\Application\Config\ParserTest']->assertions);
 
         $tests = $metrics->get('unitTesting')->get('tests');
-        $this->assertArrayHasKey('Test\Hal\Component\Issue\IssuerTest', $tests);
-        $this->assertEquals(6, $tests['Test\Hal\Component\Issue\IssuerTest']->assertions);
+        $this->assertArrayHasKey('Test\Hal\Component\Issuer\IssuerTest', $tests);
+        $this->assertEquals(6, $tests['Test\Hal\Component\Issuer\IssuerTest']->assertions);
     }
 
     public function testExceptionIsThrownIfJunitFileDoesNotExist(): void

--- a/tests/Metric/System/UnitTesting/xml/junit1.xml
+++ b/tests/Metric/System/UnitTesting/xml/junit1.xml
@@ -15,13 +15,13 @@
                 <testcase name="testICanParseArguments with data set #6" assertions="1" time="0.000118"/>
             </testsuite>
         </testsuite>
-        <testsuite name="Test\Hal\Component\Issue\IssuerTest"
+        <testsuite name="Test\Hal\Component\Issuer\IssuerTest"
                    file="tests/Component/Issuer/IssuerTest.php" tests="2"
                    assertions="6" failures="0" errors="0" time="0.024517">
-            <testcase name="testICanEnableIssuer" class="Test\Hal\Component\Issue\IssuerTest"
+            <testcase name="testICanEnableIssuer" class="Test\Hal\Component\Issuer\IssuerTest"
                       file="tests/Component/Issuer/IssuerTest.php" line="15"
                       assertions="5" time="0.002145"/>
-            <testcase name="testIssuerDisplayStatements" class="Test\Hal\Component\Issue\IssuerTest"
+            <testcase name="testIssuerDisplayStatements" class="Test\Hal\Component\Issuer\IssuerTest"
                       file="tests/Component/Issuer/IssuerTest.php" line="35"
                       assertions="1" time="0.022372"/>
         </testsuite>

--- a/tests/Report/Html/ComplexityReportRegressionTest.php
+++ b/tests/Report/Html/ComplexityReportRegressionTest.php
@@ -83,7 +83,9 @@ class ComplexityReportRegressionTest extends TestCase
     private function getActualTableHeader($content)
     {
         $dom = new \DOMDocument();
-        @$dom->loadHTML($content);
+        libxml_use_internal_errors(true);
+        $dom->loadHTML($content);
+        libxml_clear_errors();
 
         $xpath = new \DOMXPath($dom);
         $rows = $xpath->query('//table[contains(concat(" ",normalize-space(@class)," ")," js-sort-table ")]/thead/tr');

--- a/tests/Search/SearchTest.php
+++ b/tests/Search/SearchTest.php
@@ -38,8 +38,8 @@ class SearchTest extends TestCase
             'type' => 'class'
         ];
 
-        $classMetric = $this->getMockBuilder(ClassMetric::class)->disableOriginalConstructor()->getMock();
-        $interfaceMetric = $this->getMockBuilder(InterfaceMetric::class)->disableOriginalConstructor()->getMock();
+        $classMetric = $this->createStub(ClassMetric::class);
+        $interfaceMetric = $this->createStub(InterfaceMetric::class);
 
         $search = new Search('my-search', $config);
 

--- a/tests/Violation/Class_/BlobTest.php
+++ b/tests/Violation/Class_/BlobTest.php
@@ -18,7 +18,7 @@ class BlobTest extends \PHPUnit\Framework\TestCase
     #[DataProvider('provideExamples')]
     public function testGlobIsFound($expected, $nbMethodsPublic, $lcom, $nbExternals): void
     {
-        $class = $this->getMockBuilder(ClassMetric::class)->disableOriginalConstructor()->getMock();
+        $class = $this->createStub(ClassMetric::class);
 
         $violations = new Violations();
         $class->method('get')->willReturnCallback(function ($param) use (

--- a/tests/Violation/Package/StableDependenciesPrincipleTest.php
+++ b/tests/Violation/Package/StableDependenciesPrincipleTest.php
@@ -33,7 +33,7 @@ class StableDependenciesPrincipleTest extends TestCase
         $expectedViolationCount
     ): void {
         $violations = new Violations();
-        $metric = $this->getMockBuilder(PackageMetric::class)->disableOriginalConstructor()->getMock();
+        $metric = $this->createStub(PackageMetric::class);
         $metric->method('getInstability')->willReturn($packageInstability);
         $metric->method('getDependentInstabilities')->willReturn($dependentInstabilities);
         $metric->method('get')->willReturn($violations);


### PR DESCRIPTION
Hi,

thanks for maintaining this project. Could we include this on the main-stream, these are some details I noticed when running the tests for the project when creating  https://github.com/phpmetrics/PhpMetrics/pull/536

----

Add returns types to HashMap interface. 
Correct namespace on IssuerTest. 
Avoid using warning silence operator.