### PR TITLE
[#533] Way to set the composer path

### DIFF
--- a/src/Hal/Application/Config/Validator.php
+++ b/src/Hal/Application/Config/Validator.php
@@ -64,12 +64,21 @@ class Validator
             $config->set('composer', true);
         }
 
-        if (function_exists('filter_var')) {
-            $config->set('composer', filter_var($config->get('composer'), FILTER_VALIDATE_BOOLEAN));
+        // The "composer" option is dual-purpose:
+        //  - a boolean enabling/disabling the Composer analysis (default: true);
+        //  - a path to a composer.json (file or directory) used to decouple the
+        //    dependency discovery from the analyzed directories.
+        // Any value that is not a boolean-like keyword is kept as-is (a path), and
+        // the Composer analysis stays enabled.
+        $composer = $config->get('composer');
+        if (is_string($composer) && !in_array(strtolower(trim($composer)), ['true', 'false', '1', '0', 'yes', 'no', 'on', 'off', ''], true)) {
+            $config->set('composer', trim($composer));
+        } elseif (function_exists('filter_var')) {
+            $config->set('composer', filter_var($composer, FILTER_VALIDATE_BOOLEAN));
         } else {
             // When PHP is not compiled with the filter extension, we need to do it manually
-            $bool = $config->get('composer');
-            if( is_string($bool) ) {
+            $bool = $composer;
+            if (is_string($bool)) {
                 $bool = strtolower($bool);
                 $bool = in_array($bool, ['true', '1', 'yes', 'on'], true);
             }
@@ -112,6 +121,9 @@ Optional:
     --config=<file>                   Use a file for configuration. File can be a JSON, YAML or INI file.
     --exclude=<directory>             List of directories to exclude, separated by a comma (,)
     --extensions=<php,inc>            List of extensions to parse, separated by a comma (,)
+    --composer[=<path|bool>]          Composer dependency analysis. Set to "false" to disable it. Set to a
+                                      composer.json path (file or directory) to decouple the dependency
+                                      discovery from the analyzed directories (default: enabled, auto-discovery).
     --metrics                         Display list of available metrics
     --report-html=<directory>         Folder where report HTML will be generated
     --report-csv=<file>               File where report CSV will be generated

--- a/src/Hal/Metric/System/Packages/Composer/Composer.php
+++ b/src/Hal/Metric/System/Packages/Composer/Composer.php
@@ -77,13 +77,19 @@ class Composer
     {
         $rawRequirements = [[]];
 
-        // find composer.json files
-        $exclude = $this->config->has('exclude') ? $this->config->get('exclude') : [];
-        $finder = new Finder(['json'], $exclude);
+        $composer = $this->config->get('composer');
+        if (\is_string($composer) && '' !== $composer) {
+            // A composer path is explicitly provided: read it directly.
+            $files = $this->composerFilesFromPath($composer, 'json');
+        } else {
+            // find composer.json files
+            $exclude = $this->config->has('exclude') ? $this->config->get('exclude') : [];
+            $finder = new Finder(['json'], $exclude);
 
-        // include root dir by default
-        $files = $this->config->has('files') ? $this->config->get('files') : ['./'];
-        $files = $finder->fetch($files);
+            // include root dir by default
+            $files = $this->config->has('files') ? $this->config->get('files') : ['./'];
+            $files = $finder->fetch($files);
+        }
 
         foreach ($files as $filename) {
             if (!\preg_match('/composer(-dist)?\.json/', $filename)) {
@@ -110,13 +116,19 @@ class Composer
     {
         $rawInstalled = [[]];
 
-        // Find composer.lock file
-        $exclude = $this->config->has('exclude') ? $this->config->get('exclude') : [];
-        $finder = new Finder(['lock'], $exclude);
+        $composer = $this->config->get('composer');
+        if (\is_string($composer) && '' !== $composer) {
+            // A composer path is explicitly provided: read the sibling composer.lock.
+            $files = $this->composerFilesFromPath($composer, 'lock');
+        } else {
+            // Find composer.lock file
+            $exclude = $this->config->has('exclude') ? $this->config->get('exclude') : [];
+            $finder = new Finder(['lock'], $exclude);
 
-        // include root dir by default
-        $files = $this->config->has('files') ? $this->config->get('files') : ['./'];
-        $files = $finder->fetch($files);
+            // include root dir by default
+            $files = $this->config->has('files') ? $this->config->get('files') : ['./'];
+            $files = $finder->fetch($files);
+        }
 
         // List all composer.lock found in the project.
         foreach ($files as $filename) {
@@ -142,5 +154,29 @@ class Composer
         }
 
         return \call_user_func_array('array_merge', $rawInstalled);
+    }
+
+    /**
+     * Resolves the composer file to read when the "composer" option holds an explicit
+     * path, decoupling the discovery from the analyzed directories.
+     *
+     * The given path may point either to a composer.json file or to the directory that
+     * contains it. The composer.lock is looked up as a sibling of the composer.json.
+     *
+     * @param string $composer  The explicit path provided through the "composer" option.
+     * @param string $extension Either "json" (composer.json) or "lock" (composer.lock).
+     * @return array List containing the matching filename, or empty if it does not exist.
+     */
+    private function composerFilesFromPath($composer, $extension)
+    {
+        $composerJson = \is_dir($composer)
+            ? \rtrim($composer, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'composer.json'
+            : $composer;
+
+        $filename = 'lock' === $extension
+            ? \dirname($composerJson) . DIRECTORY_SEPARATOR . 'composer.lock'
+            : $composerJson;
+
+        return \is_file($filename) ? [$filename] : [];
     }
 }

--- a/tests/Application/Config/ValidatorComposerTest.php
+++ b/tests/Application/Config/ValidatorComposerTest.php
@@ -1,0 +1,75 @@
+<?php
+namespace Test\Hal\Application\Config;
+
+use Hal\Application\Config\Config;
+use Hal\Application\Config\Validator;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Focused on the dual-purpose "composer" option (boolean toggle vs. explicit path).
+ *
+ * @group application
+ * @group config
+ * @group composer
+ */
+class ValidatorComposerTest extends \PHPUnit\Framework\TestCase
+{
+    private function validated(array $extra)
+    {
+        $config = new Config();
+        // A valid, existing directory is required by the validator.
+        $config->set('files', [__DIR__]);
+        $config->fromArray($extra);
+
+        $validator = new Validator();
+        $validator->validate($config);
+
+        return $config;
+    }
+
+    public function testComposerDefaultsToEnabled(): void
+    {
+        $config = $this->validated([]);
+        $this->assertTrue($config->get('composer'));
+    }
+
+    /**
+     * @dataProvider provideBooleanValues
+     */
+    #[DataProvider('provideBooleanValues')]
+    public function testComposerBooleanKeywordsAreCoercedToBool($value, $expected): void
+    {
+        $config = $this->validated(['composer' => $value]);
+        $this->assertSame($expected, $config->get('composer'));
+    }
+
+    public static function provideBooleanValues()
+    {
+        return [
+            [true, true],
+            [false, false],
+            ['true', true],
+            ['false', false],
+            ['1', true],
+            ['0', false],
+            ['yes', true],
+            ['no', false],
+            ['on', true],
+            ['off', false],
+            ['', false],
+        ];
+    }
+
+    public function testComposerPathIsKeptAsString(): void
+    {
+        $path = './some/nested/composer.json';
+        $config = $this->validated(['composer' => $path]);
+        $this->assertSame($path, $config->get('composer'));
+    }
+
+    public function testComposerPathIsTrimmed(): void
+    {
+        $config = $this->validated(['composer' => '  ./composer.json  ']);
+        $this->assertSame('./composer.json', $config->get('composer'));
+    }
+}

--- a/tests/Metric/System/Packages/Composer/ComposerTest.php
+++ b/tests/Metric/System/Packages/Composer/ComposerTest.php
@@ -1,0 +1,127 @@
+<?php
+namespace Test\Hal\Metric\System\Packages\Composer;
+
+use Hal\Application\Config\Config;
+use Hal\Metric\System\Packages\Composer\Composer;
+
+/**
+ * Exposes the protected discovery methods so the file resolution logic can be
+ * tested without hitting the network (Packagist) through calculate().
+ */
+class ComposerTestable extends Composer
+{
+    public function jsonRequirements()
+    {
+        return $this->getComposerJsonRequirements();
+    }
+
+    public function lockInstalled(array $rootPackageRequirements)
+    {
+        return $this->getComposerLockInstalled($rootPackageRequirements);
+    }
+}
+
+/**
+ * @group metric
+ * @group composer
+ */
+class ComposerTest extends \PHPUnit\Framework\TestCase
+{
+    private function fixture($relative = '')
+    {
+        return __DIR__ . '/fixtures/project' . $relative;
+    }
+
+    private function build(array $configValues)
+    {
+        $config = new Config();
+        $config->fromArray($configValues);
+
+        return new ComposerTestable($config, []);
+    }
+
+    /**
+     * Historical behaviour: when the analyzed directory contains the composer.json,
+     * it is discovered as before (composer enabled, no explicit path).
+     */
+    public function testItDiscoversComposerJsonInsideAnalyzedDirectory(): void
+    {
+        $composer = $this->build(['files' => [$this->fixture()]]);
+
+        $requirements = $composer->jsonRequirements();
+
+        $this->assertArrayHasKey('monolog/monolog', $requirements);
+        $this->assertArrayHasKey('acme/private', $requirements);
+    }
+
+    /**
+     * Backward-compatible: analyzing only ./app (which has no composer.json) finds
+     * no requirements when no explicit composer path is provided.
+     */
+    public function testItFindsNoRequirementsWhenComposerJsonIsOutsideAnalyzedDirectory(): void
+    {
+        $composer = $this->build(['files' => [$this->fixture('/app')]]);
+
+        $this->assertSame([], $composer->jsonRequirements());
+    }
+
+    /**
+     * New behaviour: --composer=<path> decouples composer.json discovery from the
+     * analyzed directories, pointing to a file.
+     */
+    public function testComposerPathOptionResolvesRequirementsFromFile(): void
+    {
+        $composer = $this->build([
+            'files' => [$this->fixture('/app')],
+            'composer' => $this->fixture('/composer.json'),
+        ]);
+
+        $requirements = $composer->jsonRequirements();
+
+        $this->assertArrayHasKey('monolog/monolog', $requirements);
+        $this->assertArrayHasKey('acme/private', $requirements);
+    }
+
+    /**
+     * --composer=<path> may also point to the directory holding composer.json.
+     */
+    public function testComposerPathOptionResolvesRequirementsFromDirectory(): void
+    {
+        $composer = $this->build([
+            'files' => [$this->fixture('/app')],
+            'composer' => $this->fixture(),
+        ]);
+
+        $this->assertArrayHasKey('monolog/monolog', $composer->jsonRequirements());
+    }
+
+    /**
+     * The composer.lock sibling of the given composer path is used for the
+     * installed versions.
+     */
+    public function testComposerPathOptionResolvesInstalledFromSiblingLock(): void
+    {
+        $composer = $this->build([
+            'files' => [$this->fixture('/app')],
+            'composer' => $this->fixture('/composer.json'),
+        ]);
+
+        $installed = $composer->lockInstalled(['monolog/monolog']);
+
+        $this->assertSame(['monolog/monolog' => '1.25.3'], $installed);
+    }
+
+    /**
+     * An unresolvable composer path yields no files instead of raising an error.
+     */
+    public function testComposerPathOptionWithMissingFileReturnsEmpty(): void
+    {
+        $composer = $this->build([
+            'files' => [$this->fixture('/app')],
+            'composer' => $this->fixture('/does-not-exist/composer.json'),
+        ]);
+
+        $this->assertSame([], $composer->jsonRequirements());
+        $this->assertSame([], $composer->lockInstalled(['monolog/monolog']));
+    }
+}

--- a/tests/Metric/System/Packages/Composer/fixtures/project/app/Foo.php
+++ b/tests/Metric/System/Packages/Composer/fixtures/project/app/Foo.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Acme\App;
+
+class Foo
+{
+    public function bar()
+    {
+        return 42;
+    }
+}

--- a/tests/Metric/System/Packages/Composer/fixtures/project/composer.json
+++ b/tests/Metric/System/Packages/Composer/fixtures/project/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "phpmetrics/fixture",
+    "require": {
+        "php": ">=5.6",
+        "monolog/monolog": "^1.0",
+        "acme/private": "^2.0"
+    }
+}

--- a/tests/Metric/System/Packages/Composer/fixtures/project/composer.lock
+++ b/tests/Metric/System/Packages/Composer/fixtures/project/composer.lock
@@ -1,0 +1,12 @@
+{
+    "packages": [
+        {
+            "name": "monolog/monolog",
+            "version": "1.25.3"
+        },
+        {
+            "name": "some/other",
+            "version": "3.1.0"
+        }
+    ]
+}


### PR DESCRIPTION
Modify the `--composer`. This option accepts now `--composer=<false|path>`

Fixes #533 