### PR TITLE
Clarify that --exclude replaces the default exclusion list

### DIFF
--- a/src/Hal/Application/Application.php
+++ b/src/Hal/Application/Application.php
@@ -9,6 +9,7 @@ use Hal\Application\Config\Validator;
 use Hal\Component\File\Finder;
 use Hal\Component\Issue\Issuer;
 use Hal\Component\Output\CliOutput;
+use Hal\Component\Output\Output;
 use Hal\Metric\SearchMetric;
 use Hal\Report;
 use Hal\Search\PatternSearcher;
@@ -52,6 +53,10 @@ class Application
             exit(0);
         }
 
+        // the validator injects the default exclusion list, so remember whether
+        // the user provided their own before validating
+        $hasCustomExclude = $config->has('exclude');
+
         try {
             (new Validator())->validate($config);
         } catch (ConfigException $e) {
@@ -67,6 +72,10 @@ class Application
         // find files
         $finder = new Finder($config->get('extensions'), $config->get('exclude'));
         $files = $finder->fetch($config->get('files'));
+
+        if ($hasCustomExclude) {
+            $this->warnIfVendorIsAnalyzed($files, $output);
+        }
 
         // analyze
         try {
@@ -126,5 +135,30 @@ class Application
         $output->writeln('');
         $output->writeln('<success>Done</success>');
         $output->writeln('');
+    }
+
+    /**
+     * A custom --exclude replaces the default exclusion list instead of extending
+     * it: warn the user when files located in a "vendor" directory are about to
+     * be analyzed.
+     *
+     * @param string[] $files files collected by the finder, exclusions already applied
+     * @param Output $output
+     */
+    public function warnIfVendorIsAnalyzed(array $files, Output $output)
+    {
+        $needle = DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR;
+        foreach ($files as $file) {
+            if (false !== strpos($file, $needle)) {
+                $output->writeln(sprintf(
+                    '<warning>[!] Files located in a "vendor" directory are included in the analysis. '
+                    . 'Note that the --exclude option replaces the default exclusion list (%s) '
+                    . 'instead of extending it.</warning>',
+                    Validator::DEFAULT_EXCLUDE
+                ));
+                $output->writeln('');
+                return;
+            }
+        }
     }
 }

--- a/src/Hal/Application/Config/Validator.php
+++ b/src/Hal/Application/Config/Validator.php
@@ -13,6 +13,8 @@ use Hal\Search\SearchesValidator;
  */
 class Validator
 {
+    const DEFAULT_EXCLUDE = 'vendor,test,Test,tests,Tests,testing,Testing,bower_components,node_modules,cache,spec';
+
     /**
      * @param Config $config
      * @throws ConfigException
@@ -37,10 +39,7 @@ class Validator
 
         // excluded directories
         if (!$config->has('exclude')) {
-            $config->set(
-                'exclude',
-                'vendor,test,Test,tests,Tests,testing,Testing,bower_components,node_modules,cache,spec'
-            );
+            $config->set('exclude', self::DEFAULT_EXCLUDE);
         }
 
         // retro-compatibility with excludes as string in config files
@@ -107,6 +106,7 @@ class Validator
      */
     public function help()
     {
+        $defaultExclude = self::DEFAULT_EXCLUDE;
         return <<<EOT
 Usage:
 
@@ -119,7 +119,10 @@ Required:
 Optional:
 
     --config=<file>                   Use a file for configuration. File can be a JSON, YAML or INI file.
-    --exclude=<directory>             List of directories to exclude, separated by a comma (,)
+    --exclude=<directory>             List of directories to exclude, separated by a comma (,).
+                                      Caution: this option replaces the default exclusion list
+                                      instead of extending it. Default:
+                                      {$defaultExclude}
     --extensions=<php,inc>            List of extensions to parse, separated by a comma (,)
     --composer[=<path|bool>]          Composer dependency analysis. Set to "false" to disable it. Set to a
                                       composer.json path (file or directory) to decouple the dependency

--- a/tests/Application/ApplicationVendorWarningTest.php
+++ b/tests/Application/ApplicationVendorWarningTest.php
@@ -1,0 +1,51 @@
+<?php
+namespace Test\Hal\Application;
+
+use Hal\Application\Application;
+use Hal\Component\Output\TestOutput;
+use Polyfill\TestCaseCompatible;
+
+/**
+ * Focused on the warning displayed when a custom exclusion list lets files
+ * located in a "vendor" directory enter the analysis.
+ *
+ * @group application
+ * @group config
+ */
+class ApplicationVendorWarningTest extends \PHPUnit\Framework\TestCase
+{
+    use TestCaseCompatible;
+
+    private function warningFor(array $files)
+    {
+        $files = str_replace('/', DIRECTORY_SEPARATOR, $files);
+
+        $output = new TestOutput();
+        (new Application())->warnIfVendorIsAnalyzed($files, $output);
+
+        return (string) $output->output;
+    }
+
+    public function testWarnsWhenVendorFilesAreAnalyzed(): void
+    {
+        $warning = $this->warningFor(['/app/src/Foo.php', '/app/vendor/acme/lib/Bar.php']);
+        $this->assertStringContainsString('<warning>[!] ', $warning);
+        $this->assertStringContainsString('vendor', $warning);
+    }
+
+    public function testWarnsWhenVendorIsNestedInAnalyzedDirectories(): void
+    {
+        $warning = $this->warningFor(['/app/src/module/vendor/Bar.php']);
+        $this->assertStringContainsString('<warning>', $warning);
+    }
+
+    public function testStaysQuietWhenNoVendorFileIsAnalyzed(): void
+    {
+        $this->assertSame('', $this->warningFor(['/app/src/Foo.php', '/app/lib/Bar.php']));
+    }
+
+    public function testStaysQuietOnVendorLookalikeDirectories(): void
+    {
+        $this->assertSame('', $this->warningFor(['/app/vendor-tools/Foo.php', '/app/myvendor/Bar.php']));
+    }
+}

--- a/tests/Application/Config/ValidatorExcludeTest.php
+++ b/tests/Application/Config/ValidatorExcludeTest.php
@@ -1,0 +1,49 @@
+<?php
+namespace Test\Hal\Application\Config;
+
+use Hal\Application\Config\Config;
+use Hal\Application\Config\Validator;
+use Polyfill\TestCaseCompatible;
+
+/**
+ * Focused on the "exclude" option (default exclusion list vs. custom one).
+ *
+ * @group application
+ * @group config
+ */
+class ValidatorExcludeTest extends \PHPUnit\Framework\TestCase
+{
+    use TestCaseCompatible;
+
+    private function validated(array $extra)
+    {
+        $config = new Config();
+        // A valid, existing directory is required by the validator.
+        $config->set('files', [__DIR__]);
+        $config->fromArray($extra);
+
+        $validator = new Validator();
+        $validator->validate($config);
+
+        return $config;
+    }
+
+    public function testDefaultExclusionListIsAppliedWhenNotProvided(): void
+    {
+        $config = $this->validated([]);
+        $this->assertSame(explode(',', Validator::DEFAULT_EXCLUDE), $config->get('exclude'));
+    }
+
+    public function testCustomExclusionListReplacesDefaultInsteadOfExtendingIt(): void
+    {
+        $config = $this->validated(['exclude' => 'foo,bar']);
+        $this->assertSame(['foo', 'bar'], $config->get('exclude'));
+    }
+
+    public function testHelpWarnsAboutExclusionListReplacement(): void
+    {
+        $help = (new Validator())->help();
+        $this->assertStringContainsString('replaces the default exclusion list', $help);
+        $this->assertStringContainsString(Validator::DEFAULT_EXCLUDE, $help);
+    }
+}


### PR DESCRIPTION
The --exclude option replaces the default exclusion list instead of extending it. This is intended, but easy to miss: a custom exclusion list silently brings vendor code into the analysis, which inflates metrics such as LOC (see #364).

<img width="1059" height="636" alt="Capture d’écran du 2026-07-29 07-25-50" src="https://github.com/user-attachments/assets/08ba7675-af49-495b-a24d-1f64152b8d64" />
