### PR TITLE
[BC] simplified et secured releasing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,10 @@ name: Release
 # Manual release: you give the version, the job runs the release you used to run
 # locally with `make release TAG=vX.Y.Z`, on a runner instead of in Docker.
 #
-# It builds the artifacts (make build), bumps the version (make tag), pushes the
-# "releasing vX.Y.Z" commit and the tag on master, then publishes the GitHub
-# release with the artifacts attached.
+# It builds the artifacts (make build), bumps the version (make tag), commits the
+# bump and the built artifacts, tags that commit and pushes the tag (master is
+# protected and is never pushed to: the commit only lives under the tag), then
+# publishes the GitHub release with the artifacts attached.
 #
 # The release is published as a pre-release, so GitHub never labels it "latest".
 # Once the artifacts are checked, edit the release and untick "Set as a
@@ -73,14 +74,13 @@ jobs:
             # Same steps as the `new_git_version` target of the Makefile, inlined
             # because its commit message relies on the `semver` binary, which
             # only exists in the phpmetrics/releasing Docker image.
-            -   name: Push commit and tag
+            -   name: Tag and push
                 run: |
                     git config user.name 'github-actions[bot]'
                     git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
                     git add .github/ISSUE_TEMPLATE/Bug_report.md .github/ISSUE_TEMPLATE/Feature_request.md src/functions.php doc/installation.md artifacts/* releases/*
                     git commit -m "releasing $VERSION"
                     git tag "$VERSION" -m "releasing $VERSION"
-                    git push origin master
                     git push origin "$VERSION"
 
             -   name: Publish release

--- a/Makefile
+++ b/Makefile
@@ -33,12 +33,12 @@ tag: check-tag
 	make changelog-deb
 
 
-# Tag git with last release
+# Tag git with last release. master is protected and is never pushed to: the
+# commit only lives under the tag.
 new_git_version: build tag
 	git add .github/ISSUE_TEMPLATE/Bug_report.md .github/ISSUE_TEMPLATE/Feature_request.md src/functions.php doc/installation.md artifacts/* releases/*
 	git commit -m "releasing `semver tag`"
 	git tag $(TAG) -m "releasing $(TAG)"
-	git push -u origin master
 	git push origin $(TAG)
 
 docker:

--- a/artifacts/Makefile
+++ b/artifacts/Makefile
@@ -1,5 +1,7 @@
-# Latest tag reachable from HEAD (git tag alone sorts alphabetically: v3.0.0rc7 > v2.10.0)
-CURRENT_TAG=$(shell git describe --tags --abbrev=0)
+# Latest tag by version, not by reachability from HEAD: since release commits are
+# no longer merged into master, git describe wouldn't find them as ancestors
+# (git tag alone sorts alphabetically: v3.0.0rc7 > v2.10.0)
+CURRENT_TAG=$(shell git tag --sort=-v:refname | head -1)
 BUILD_DIR=releases
 
 include artifacts/phar/Makefile

--- a/artifacts/debian/Makefile
+++ b/artifacts/debian/Makefile
@@ -21,7 +21,7 @@ build-deb:
 changelog-deb:
 	@echo "phpmetrics ($(shell echo $(TAG) | sed s/^v//)) unstable; urgency=low" >/tmp/changelog
 	@echo >> artifacts/debian/changelog
-	@git log $(CURRENT_TAG)...HEAD --pretty=format:'   * %s ' --reverse >> /tmp/changelog
+	@git log $(CURRENT_TAG)..HEAD --pretty=format:'   * %s ' --reverse >> /tmp/changelog
 	@echo >> /tmp/changelog
 	@echo >> /tmp/changelog
 	@echo  "  -- Jean-François Lépine <lepinejeanfrancois@yahoo.fr>  $(shell date --rfc-2822)" >> /tmp/changelog


### PR DESCRIPTION
**For over 10 years, this repo has committed built release artifacts (phar, binaries, .deb) directly to master on every release.** This bloats the repository and, worse, forced a bypass of master's branch protection, an attack surface that could let compromised artifacts be pushed under the guise of a routine release.

**GitHub Releases have existed since 2017 on this repo,** giving users nearly a decade to adopt them. They're a safer distribution channel: they support proper checksums, and GitHub flags malicious overwrites of published releases. Keeping the old commit-to-master path added no benefit and only complicated the build process.

**For these reasons, this PR drops pushing release artifacts to master entirely.**

### Change

Only the release tag is pushed now; the version-bump commit still exists but is reachable  solely via the tag, no master push, no bypass needed. CURRENT_TAG switched from git describe --tags (ancestry-based) to a version-sorted git tag lookup, and the Debian changelog range from ... to .., since the tag commit is no longer guaranteed to be an ancestor of master.

### Impact

Releases no longer touch master. Published artifacts are unchanged; only their distribution channel (GitHub Releases exclusively) and integrity guarantees improve.
  
