### PR TITLE
docs: align PHP support with CI

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -18,7 +18,7 @@ Thanks for your help.
 PhpMetrics has several goals:
 + be stable
 + be performant
-+ run on the **maximum of PHP versions** (PHP 5.3 to PHP 8.4)
++ run on the **maximum of PHP versions** (PHP 5.6 to PHP 8.4)
 + be installable everywhere, **without dependency conflicts**
 
 For these reasons, the code of PhpMetrics is intentionally written in "legacy" PHP.


### PR DESCRIPTION
## Summary

- update the contribution guide's minimum supported PHP version from 5.3 to 5.6
- keep the documented range aligned with the current CI matrix

Fixes #534

## Verification

- confirmed CI tests stable PHP versions 5.6 through 8.4
- confirmed the obsolete 5.3 range is absent from the contribution guide
- `git diff --check`
